### PR TITLE
get download url from file and pass in access token instead of shared ur...

### DIFF
--- a/lib/browse_everything/driver/box.rb
+++ b/lib/browse_everything/driver/box.rb
@@ -41,10 +41,10 @@ module BrowseEverything
 
       def link_for(path)
         file = box_client.file(path)
-        file.create_shared_link
-        link = file.shared_link
-        extras = link.unshared_at.nil? ? {} : { expires: link.unshared_at }
-        [link.download_url,extras]
+        download_url = file.download_url
+        auth_header = {'Authorization' => "Bearer #{@token}"}
+        extras = { auth_header: auth_header, expires: 1.hour.from_now , file_name:file.name }
+        [download_url,extras]
       end
 
       def details(f)

--- a/lib/browse_everything/driver/google_drive.rb
+++ b/lib/browse_everything/driver/google_drive.rb
@@ -61,7 +61,8 @@ module BrowseEverything
         api_result = oauth_client.execute(api_method: api_method, parameters: {fileId: id})
         download_url = JSON.parse(api_result.response.body)["downloadUrl"]
         auth_header = {'Authorization' => "Bearer #{oauth_client.authorization.access_token.to_s}"}
-        [download_url,{ auth_header: auth_header, expires: 1.hour.from_now }]
+        extras = { auth_header: auth_header, expires: 1.hour.from_now, file_name:api_result.data.title }
+        [download_url, extras]
       end
 
       def auth_link


### PR DESCRIPTION
This a pull request to fix the issue with box and send file name for google drive and box since it gives some random name in download url.
