### PR TITLE
Fixing broken file system spec

### DIFF
--- a/spec/unit/file_system_spec.rb
+++ b/spec/unit/file_system_spec.rb
@@ -80,6 +80,6 @@ describe BrowseEverything::Driver::FileSystem do
 
   describe "#link_for('/path/to/file')" do
     subject { provider.link_for('/path/to/file') }
-    it { should == "file:///path/to/file" }
+    it { should == ["file:///path/to/file", {:file_name=>"file"}] }
   end
 end


### PR DESCRIPTION
I believe the BrowseEverything::Driver::Base also needs fixing to
reflect that the #link_for method should be returning an Array of
two elements.
