### PR TITLE
Minor css fix for blacklight compatibility

### DIFF
--- a/app/assets/stylesheets/browse_everything.css.scss
+++ b/app/assets/stylesheets/browse_everything.css.scss
@@ -32,6 +32,7 @@
   position: fixed !important;
   margin: 0 0 0 -37.5%;
   left: 50%;
+  top: 10%;
   width: 75%;
 
   .modal-body {


### PR DESCRIPTION
Explicitly set #browse_everything {top: 10%}.  This overrides blacklight's css which sets .modal.fade.in {top: 50%}
