### PR TITLE
Removing div count check so that div can be created

### DIFF
--- a/app/assets/javascripts/browse_everything/behavior.js.coffee
+++ b/app/assets/javascripts/browse_everything/behavior.js.coffee
@@ -4,8 +4,7 @@ $(document).ready ->
   dialog = $('div#browse-everything')
 
   initialize = (obj,options) ->
-    if dialog.length == 0
-      dialog = $('<div id="browse-everything" class="ev-browser modal fade"></div>').hide().appendTo('body')
+    dialog = $('<div id="browse-everything" class="ev-browser modal fade"></div>').hide().appendTo('body')
     dialog.modal({ backdrop: 'static', show: false });
     context[obj] = 
       opts: $.extend(true, {}, options)


### PR DESCRIPTION
Removing checking div count since it was never reset and did not work well if you have to repeat modal window on different view. Not sure if this is the best solution but this is what works for curate.

Moving from one page to another page modal div was never recreated and need to had refresh the page. But when there are more than one div with same id it did not cause any problem that I know of.
