### PR TITLE
Encoding single quote in file name to make the input html resolve correc...

### DIFF
--- a/app/assets/javascripts/browse_everything/behavior.js.coffee
+++ b/app/assets/javascripts/browse_everything/behavior.js.coffee
@@ -83,7 +83,7 @@ $ ->
     event.preventDefault()
     target = $(this).closest('*[data-ev-location]')
     target_form = $('form.ev-submit-form')
-    file_location = target.data('ev-location')
+    file_location = target.data('ev-location').replace(/'/g, "&apos;")
     target.toggleClass('ev-selected')
     if target.hasClass('ev-selected')
       hidden_input = $("<input type='hidden' class='ev-url' name='selected_files[]' value='#{file_location}'>")


### PR DESCRIPTION
...tly

I have a file like cam156's file.pdf in drop box this name is causing the insertion of the hidden input to break as it think s the file name is "cam156" and the rest is lost.  Encoding the embedded single quote gets around this issue.
