### PR TITLE
Adding a progress bar so the screen loader knows when folders are loadin...

### DIFF
--- a/app/views/browse_everything/_auth.html.erb
+++ b/app/views/browse_everything/_auth.html.erb
@@ -1,3 +1,3 @@
 <h2><%=t('browse_everything.auth_prompt.head', provider: provider.name)%></h2>
 <p><%=t('browse_everything.auth_prompt.text', provider: provider.name)%></p>
-<p><%= link_to t('browse_everything.auth_prompt.button_text', provider: provider.name), auth_link, class:"btn btn-primary ev-auth", target:'blank' %></p>
+<p><%= link_to t('browse_everything.auth_prompt.button_text', provider: provider.name), auth_link, class:"btn btn-primary ev-auth", target:'blank', id:'provider_auth' %></p>

--- a/app/views/browse_everything/_file.html.erb
+++ b/app/views/browse_everything/_file.html.erb
@@ -1,17 +1,19 @@
 <% unless file.relative_parent_path? %>
-<tr tabindex="-1" data-ev-location="<%= file.location %>" data-tt-id="<%=path%>" data-tt-parent-id="<%=parent%>" data-tt-branch="<%=file.container? ? 'true' : 'false'%>">
-  <td class="<%=file.container? ? 'ev-container' : 'ev-file'%> ev-file-name">
-    <span class="<%=file.container? ? 'folder' : 'file'%>">
-      <%= link_to(file.name, browse_everything_engine.contents_path(provider_name,file.id), {:class=>'ev-link'}) %>
-    </span>
+<tr role="row" tabindex="-1" data-ev-location="<%= file.location %>" data-tt-id="<%=path%>" data-tt-parent-id="<%=parent%>" data-tt-branch="<%=file.container? ? 'true' : 'false'%>">
+  <td role="gridcell" class="<%=file.container? ? 'ev-container' : 'ev-file'%> ev-file-name">
+      <%= link_to browse_everything_engine.contents_path(provider_name,file.id), {:class=>'ev-link'} do %>
+        <span class="<%=file.container? ? 'folder' : 'file'%>" aria-hidden="true"/>
+        <%= file.name %>
+        <span class="sr-only"><%= file.container? ? ', folder' : ', file' %> </span>
+      <% end %>
   </td>
-  <td class="ev-file-size">
+  <td role="gridcell" class="ev-file-size">
     <%= number_to_human_size(file.size).sub(/Bytes/,'bytes') %>
   </td>
-  <td class="ev-file-kind">
+  <td role="gridcell" class="ev-file-kind">
     <%= file.type %>
   </td>
-  <td class="ev-file-date">
+  <td role="gridcell" class="ev-file-date">
     <%= file.mtime.strftime('%F %R') %>
   </td>
 </tr>

--- a/app/views/browse_everything/_files.html.erb
+++ b/app/views/browse_everything/_files.html.erb
@@ -1,11 +1,16 @@
 <% if provider.present? %>
-  <table id="file-list" tabindex="-1">
+  <div class="progress" id="loading_progress" aria-live="polite">
+    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 100%;">
+      100% Complete
+    </div>
+  </div>
+  <table id="file-list" role="grid" tabindex="-1" title="Choose files to upload from the table below" aria-live="polite">
     <thead>
-      <tr>
-        <th>Name</th>
-        <th>Size</th>
-        <th>Kind</th>
-        <th>Modified</th>
+      <tr role="row" tabindex="-1">
+        <th role="columnheader">Name</th>
+        <th role="columnheader">Size</th>
+        <th role="columnheader">Kind</th>
+        <th role="columnheader">Modified</th>
       </tr>
     </thead>
     <% provider.contents(browse_path).each_with_index do |file,index| %>


### PR DESCRIPTION
...g, and making the file link more screen reader friendly

Before this pull request the screen reader does not get notified that anything is happening on the page, and the sighted user does not have much indication that things are happening as the busy cursor does not show over the table.

I am willing to hide the progress bar from the sighted user and I fully admit the progress calculation is a bit dumb, but it is better than nothing. 
