### PR TITLE
Stop explicitly requiring jquery

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ download the files.
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this lines to your application's Gemfile:
 
+    gem 'jquery-rails'
     gem 'browse-everything'
 
 And then execute:
@@ -44,7 +45,13 @@ If you prefer not to use the generator, or need info on how to set up providers 
 
 Add `@import "browse_everything";` to your application.css.scss
 
-Add `//= require browse_everything` to your application.js
+In `app/assets/javascripts/application.js` include jquery and the BrowseEverything
+
+```javascript
+//= require jquery
+//= require browse_everything
+```
+
 
 ## Usage
 

--- a/app/assets/javascripts/browse_everything.js
+++ b/app/assets/javascripts/browse_everything.js
@@ -1,4 +1,3 @@
-//= require jquery
 //= require jquery.treetable
 //= require bootstrap-sprockets
 //= require browse_everything/behavior


### PR DESCRIPTION
Instead we'll expect the host app to provide this dependency.
This allows the host app to switch jquery versions (from 1 to 2 or 3)

Fixes #163