### PR TITLE
Set stream_body option to true for http(s) files larger than 500MB

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -24,7 +24,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 10
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 26
+  Max: 28
 
 # Offense count: 1
 # Configuration parameters: CountKeywordArgs.


### PR DESCRIPTION
Forces `httparty` to stream any http(s) file larger than 500mb instead of reading it all into memory. See the `httparty` docs [here](https://github.com/jnunemaker/httparty/blob/d9c4067a9c70c6129146cb6db0ab48d32e0e8494/lib/httparty.rb#L42).