### PR TITLE
Skip files with nil size

### DIFF
--- a/app/views/browse_everything/_files.html.erb
+++ b/app/views/browse_everything/_files.html.erb
@@ -9,7 +9,7 @@
       </tr>
     </thead>
     <% provider.contents(browse_path).each_with_index do |file, index| %>
-      <% next if file.relative_parent_path? %>
+      <% next if file.relative_parent_path? or file.size.nil? %>
       <%= render :partial => 'file', :locals => { :file => file, :index => index,
         :path => browse_everything_engine.contents_path(provider_name, file.id), :parent => params[:parent] } %>
     <% end %>


### PR DESCRIPTION
Box has a feature that acts like symlinks, and it symlinked directories as regular files (not containers) with nil file size. There's no good way for BE to handle them, so let's at least not error on them.