### PR TITLE
Only require the parts of the aws-sdk that we need (s3)

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-api-client', '~> 0.9'
   spec.add_dependency 'signet'
   spec.add_dependency 'httparty'
-  spec.add_dependency 'aws-sdk'
+  spec.add_dependency 'aws-sdk-s3'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'rspec-its'

--- a/lib/browse_everything/driver/s3.rb
+++ b/lib/browse_everything/driver/s3.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-s3'
 
 module BrowseEverything
   module Driver


### PR DESCRIPTION
This is possible due to the refactoring of aws-sdk, which was released
as version 3.0