### PR TITLE
Provides remedy for cases where Google Drive auth tokens must be forcibly cleared

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,7 @@ RSpec/MultipleExpectations:
     - 'spec/unit/dropbox_spec.rb'
     - 'spec/unit/google_drive_spec.rb'
     - 'spec/features/**/*'
+    - 'spec/controllers/browse_everything_controller_spec.rb'
 
 Style/NumericLiterals:
   MinDigits: 7

--- a/app/controllers/browse_everything_controller.rb
+++ b/app/controllers/browse_everything_controller.rb
@@ -23,6 +23,8 @@ class BrowseEverythingController < ActionController::Base
     @provider_contents = provider.contents(browse_path)
     render partial: 'files', layout: !request.xhr?
   rescue StandardError => error
+    reset_provider_session!
+
     # Should an error be raised, log the error and redirect the use to reauthenticate
     logger.warn "Failed to retrieve the hosted files: #{error}"
     render partial: 'auth', layout: !request.xhr?
@@ -52,10 +54,23 @@ class BrowseEverythingController < ActionController::Base
 
   private
 
+    # Constructs or accesses an existing session manager Object
+    # @return [BrowseEverythingSession::ProviderSession] the session manager
     def provider_session
       @provider_session ||= BrowseEverythingSession::ProviderSession.new(session: session, name: provider_name)
     end
 
+    # Clears all authentication tokens, codes, and other data from the Rails session
+    def reset_provider_session!
+      return unless @provider_session
+      @provider_session.token = nil
+      @provider_session.code = nil
+      @provider_session.data = nil
+      @provider_session = nil
+    end
+
+    # Generates the authentication link for a given provider service
+    # @return [String] the authentication link
     def auth_link
       @auth_link ||= if provider.present?
                        link, data = provider.auth_link
@@ -65,20 +80,20 @@ class BrowseEverythingController < ActionController::Base
                      end # else nil, implicitly
     end
 
+    # Accesses the relative path for browsing from the Rails session
+    # @return [String]
     def browse_path
       @path ||= params[:path] || ''
     end
 
-    # Browser state cannot persist between requests to the Controller
-    # Hence, a Browser must be reinstantiated for each request using the state provided in the session
-    def browser
-      BrowserFactory.build(session: session, url_options: url_options)
-    end
-
+    # Generate the provider name from the Rails session state value
+    # @return [String]
     def provider_name_from_state
       params[:state].to_s.split(/\|/).last
     end
 
+    # Generates the name of the provider using Rails session values
+    # @return [String]
     def provider_name
       @provider_name ||= params[:provider] || provider_name_from_state
     end
@@ -87,6 +102,14 @@ class BrowseEverythingController < ActionController::Base
     # @return [BrowseEverything::Driver::Base]
     def provider
       browser.providers[provider_name]
+    end
+
+    # Constructs a browser manager Object
+    # Browser state cannot persist between requests to the Controller
+    # Hence, a Browser must be reinstantiated for each request using the state provided in the Rails session
+    # @return [BrowseEverything::Browser]
+    def browser
+      BrowserFactory.build(session: session, url_options: url_options)
     end
 
     helper_method :auth_link

--- a/lib/browse_everything/auth/google/request_parameters.rb
+++ b/lib/browse_everything/auth/google/request_parameters.rb
@@ -16,7 +16,7 @@ module BrowseEverything
           # @return [Hash]
           def default_params
             {
-              order_by: 'modifiedByMeTime,modifiedTime,folder desc,name',
+              order_by: 'folder desc,modifiedTime desc,name',
               fields: 'nextPageToken,files(name,id,mimeType,size,modifiedTime,parents,web_content_link)',
               page_size: 1000
             }

--- a/spec/controllers/browse_everything_controller_spec.rb
+++ b/spec/controllers/browse_everything_controller_spec.rb
@@ -1,13 +1,14 @@
 require 'spec_helper'
+require 'signet/errors'
 
 RSpec.describe BrowseEverythingController, type: :controller do
   routes { Rails.application.class.routes }
 
-  let(:driver) { instance_double(BrowseEverything::Driver::Base) }
+  let(:provider) { instance_double(BrowseEverything::Driver::Base) }
 
   before do
-    allow(driver).to receive(:authorized?).and_return(true)
-    allow(controller).to receive(:provider).and_return(driver)
+    allow(provider).to receive(:authorized?).and_return(true)
+    allow(controller).to receive(:provider).and_return(provider)
   end
 
   describe '#auth' do
@@ -15,11 +16,11 @@ RSpec.describe BrowseEverythingController, type: :controller do
     before do
       allow(controller).to receive(:params).and_return('code' => 'test-code')
       allow(provider_session).to receive(:data).and_return(nil)
-      allow(driver).to receive(:connect)
+      allow(provider).to receive(:connect)
       controller.auth
     end
     it 'retrieves the authorization code from the parameters' do
-      expect(driver).to have_received(:connect).with({ 'code' => 'test-code' }, nil)
+      expect(provider).to have_received(:connect).with({ 'code' => 'test-code' }, nil)
     end
   end
 
@@ -31,20 +32,42 @@ RSpec.describe BrowseEverythingController, type: :controller do
       allow(controller).to receive(:render)
     end
 
-    it 'renders the files retrieved by the driver' do
-      allow(driver).to receive(:contents).and_return([file1, file2])
+    it 'renders the files retrieved by the provider' do
+      allow(provider).to receive(:contents).and_return([file1, file2])
       controller.show
       expect(controller).to have_received(:render).with(partial: 'files', layout: true)
     end
 
-    context 'when an error occurs while retrieving the files' do
+    context 'when an authentication error occurs while retrieving the files' do
+      let(:provider_session) { instance_double(BrowseEverythingSession::ProviderSession) }
+
       before do
-        allow(driver).to receive(:contents).and_raise(StandardError)
+        controller.instance_variable_set(:@provider_session, provider_session)
+        allow(provider).to receive(:contents).and_raise(Signet::AuthorizationError)
+        allow(provider_session).to receive(:token=)
+        allow(provider_session).to receive(:code=)
+        allow(provider_session).to receive(:data=)
+        controller.show
+      end
+
+      it 'clears the Rails session of auth. data' do
+        expect(provider_session).to have_received(:token=).with(nil)
+        expect(provider_session).to have_received(:code=).with(nil)
+        expect(provider_session).to have_received(:data=).with(nil)
+        expect(provider_session.instance_variable_get(:@provider_session)).to be_nil
+      end
+    end
+
+    context 'when a remote API error occurs while retrieving the files' do
+      before do
+        allow(provider).to receive(:contents).and_raise(StandardError)
+        allow(controller).to receive(:reset_provider_session!)
         controller.show
       end
 
       it 'directs the user to reauthenticate' do
         expect(controller).to have_received(:render).with(partial: 'auth', layout: true)
+        expect(controller).to have_received(:reset_provider_session!)
       end
     end
   end

--- a/spec/controllers/browse_everything_controller_spec.rb
+++ b/spec/controllers/browse_everything_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe BrowseEverythingController, type: :controller do
     let(:file2) { instance_double(BrowseEverything::FileEntry) }
 
     before do
-      allow(driver).to receive(:contents).and_return([file1, file2])
+      allow(provider).to receive(:contents).and_return([file1, file2])
       allow(controller).to receive(:render).with(partial: 'files', layout: true)
     end
 
@@ -47,7 +47,8 @@ RSpec.describe BrowseEverythingController, type: :controller do
 
       before do
         controller.instance_variable_set(:@provider_session, provider_session)
-        allow(provider).to receive(:contents).and_raise(Signet::AuthorizationError)
+        allow(controller).to receive(:render).with(partial: 'auth', layout: true)
+        allow(controller).to receive(:render).with(partial: 'files', layout: true).and_raise(Signet::AuthorizationError)
         allow(provider_session).to receive(:token=)
         allow(provider_session).to receive(:code=)
         allow(provider_session).to receive(:data=)
@@ -64,13 +65,13 @@ RSpec.describe BrowseEverythingController, type: :controller do
 
     context 'when a remote API error occurs while retrieving the files' do
       before do
-        allow(provider).to receive(:contents).and_raise(StandardError)
+        allow(controller).to receive(:render).with(partial: 'auth', layout: true)
+        allow(controller).to receive(:render).with(partial: 'files', layout: true).and_raise(StandardError)
         allow(controller).to receive(:reset_provider_session!)
         controller.show
       end
 
       it 'directs the user to reauthenticate after attempting to render the files' do
-        controller.show
         expect(controller).to have_received(:render).with(partial: 'auth', layout: true)
         expect(controller).to have_received(:reset_provider_session!)
       end


### PR DESCRIPTION
Also modifies the default sorting for file entries returned from the Google Drive API