### PR TITLE
Ensures that the `BrowseEverything` configuration is a `ActiveSupport::HashWithIndifferentAccess` rather than a `Hash`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,7 @@ RSpec/MultipleExpectations:
     - 'spec/unit/browse_everything/driver/s3_spec.rb'
     - 'spec/features/**/*'
     - 'spec/controllers/browse_everything_controller_spec.rb'
+    - 'spec/unit/browse_everything/browser_spec.rb'
 
 Style/NumericLiterals:
   MinDigits: 7

--- a/lib/browse_everything.rb
+++ b/lib/browse_everything.rb
@@ -8,6 +8,7 @@ require 'browse_everything/retriever'
 module BrowseEverything
   autoload :Browser,   'browse_everything/browser'
   autoload :FileEntry, 'browse_everything/file_entry'
+
   module Driver
     autoload :Base,        'browse_everything/driver/base'
     autoload :FileSystem,  'browse_everything/driver/file_system'
@@ -16,6 +17,7 @@ module BrowseEverything
     autoload :GoogleDrive, 'browse_everything/driver/google_drive'
     autoload :S3,          'browse_everything/driver/s3'
   end
+
   module Auth
     module Google
       autoload :Credentials,        'browse_everything/auth/google/credentials'
@@ -28,14 +30,18 @@ module BrowseEverything
   class NotAuthorizedError < StandardError; end
 
   class << self
+    attr_writer :config
+
     def configure(value)
-      if value.nil? || value.is_a?(Hash)
-        @config = value
+      return if value.nil?
+      if value.is_a?(Hash)
+        @config = ActiveSupport::HashWithIndifferentAccess.new value
       elsif value.is_a?(String)
         config_file_content = File.read(value)
         config_file_template = ERB.new(config_file_content)
-        @config = YAML.safe_load(config_file_template.result)
-        @config.deep_symbolize_keys!
+        config_values = YAML.safe_load(config_file_template.result)
+        @config = ActiveSupport::HashWithIndifferentAccess.new config_values
+        @config.deep_symbolize_keys
 
         if @config.include? 'drop_box'
           warn '[DEPRECATION] `drop_box` is deprecated.  Please use `dropbox` instead.'

--- a/lib/browse_everything/browser.rb
+++ b/lib/browse_everything/browser.rb
@@ -13,7 +13,7 @@ module BrowseEverything
         opts = BrowseEverything.config
       end
 
-      @providers = {}
+      @providers = ActiveSupport::HashWithIndifferentAccess.new
       opts.each_pair do |driver_key, config|
         begin
           driver = driver_key.to_s
@@ -26,7 +26,7 @@ module BrowseEverything
     end
 
     def first_provider
-      @providers.each_value.to_a.first
+      @providers.to_hash.each_value.to_a.first
     end
   end
 end

--- a/lib/browse_everything/driver/base.rb
+++ b/lib/browse_everything/driver/base.rb
@@ -5,12 +5,16 @@ module BrowseEverything
     class Base
       include BrowseEverything::Engine.routes.url_helpers
 
-      attr_reader :config
       attr_accessor :token, :code
 
       def initialize(config, _session_info = {})
         @config = config
         validate_config
+      end
+
+      def config
+        @config = ActiveSupport::HashWithIndifferentAccess.new(@config) if @config.is_a? Hash
+        @config
       end
 
       def validate_config; end
@@ -61,7 +65,9 @@ module BrowseEverything
         # remove the script_name parameter from the url_options since that is causing issues
         #   with the route not containing the engine path in rails 4.2.0
         def callback_options
-          config[:url_options].reject { |k, _v| k == :script_name }
+          options = config.to_hash
+          options.deep_symbolize_keys!
+          options[:url_options].reject { |k, _v| k == :script_name }
         end
     end
   end

--- a/spec/unit/browse_everything/browser_spec.rb
+++ b/spec/unit/browse_everything/browser_spec.rb
@@ -9,30 +9,46 @@ describe BrowseEverything::Browser do
 
   let(:global_config) do
     {
-      file_system:  { home: '/global/config/home' },
-      dropbox:      { client_id: 'DropboxId', client_secret: 'DropboxClientSecret' }
+      file_system: {
+        home: '/global/config/home'
+      },
+      dropbox: {
+        client_id: 'DropboxId',
+        client_secret: 'DropboxClientSecret'
+      }
     }
   end
 
   let(:local_config) do
     {
-      file_system:  { home: '/local/config/home' },
-      dropbox:      { client_id: 'DropboxId', client_secret: 'DropboxClientSecret' },
-      url_options:  url_options
+      file_system: {
+        home: '/local/config/home'
+      },
+      dropbox: {
+        client_id: 'DropboxId',
+        client_secret: 'DropboxClientSecret'
+      },
+      url_options: url_options
     }
   end
 
   describe 'file config' do
     let(:browser) { described_class.new(url_options) }
 
-    before { allow(File).to receive(:read).and_return(file_config) }
+    before do
+      BrowseEverything.config = nil
+      allow(File).to receive(:read).and_return file_config
+    end
 
     it 'has 2 providers' do
-      expect(browser.providers.keys).to eq(%i[file_system dropbox])
+      expect(browser.providers.keys).to eq(%w[file_system dropbox])
+      expect(browser.providers[:file_system]).to be_a BrowseEverything::Driver::FileSystem
+      expect(browser.providers[:dropbox]).to be_a BrowseEverything::Driver::Dropbox
     end
 
     it 'uses the file configuration' do
       expect(browser.providers[:file_system].config[:home]).to eq('/file/config/home')
+      expect(browser.providers['file_system'].config['home']).to eq('/file/config/home')
     end
   end
 
@@ -42,11 +58,14 @@ describe BrowseEverything::Browser do
     before { BrowseEverything.configure(global_config) }
 
     it 'has 2 providers' do
-      expect(browser.providers.keys).to eq(%i[file_system dropbox])
+      expect(browser.providers.keys).to eq(%w[file_system dropbox])
+      expect(browser.providers[:file_system]).to be_a BrowseEverything::Driver::FileSystem
+      expect(browser.providers[:dropbox]).to be_a BrowseEverything::Driver::Dropbox
     end
 
     it 'uses the global configuration' do
       expect(browser.providers[:file_system].config[:home]).to eq('/global/config/home')
+      expect(browser.providers['file_system'].config['home']).to eq('/global/config/home')
     end
   end
 
@@ -54,11 +73,15 @@ describe BrowseEverything::Browser do
     let(:browser) { described_class.new(local_config) }
 
     it 'has 2 providers' do
-      expect(browser.providers.keys).to eq(%i[file_system dropbox])
+      expect(browser.providers.keys).to eq(%w[file_system dropbox])
+      expect(browser.providers[:file_system]).to be_a BrowseEverything::Driver::FileSystem
+      expect(browser.providers[:dropbox]).to be_a BrowseEverything::Driver::Dropbox
     end
 
     it 'uses the local configuration' do
-      expect(browser.providers[:file_system].config[:home]).to eq('/local/config/home')
+      file_provider = browser.providers[:file_system]
+      expect(file_provider.config[:home]).to eq('/local/config/home')
+      expect(file_provider.config['home']).to eq('/local/config/home')
     end
   end
 


### PR DESCRIPTION
Ensures backward compatibility for clients accessing the configuration options using strings as keys