### PR TITLE
Removing the rendering of relative paths to current and parent directories within the `FileSystem` Driver

### DIFF
--- a/app/views/browse_everything/_files.html.erb
+++ b/app/views/browse_everything/_files.html.erb
@@ -21,9 +21,9 @@
       <tr role="row"
           tabindex="-1"
           data-ev-location="<%= file.location %>"
-          data-tt-id="<%=path%>"
-          data-tt-parent-id="<%=parent%>"
-          data-tt-branch="<%=file.container? ? 'true' : 'false'%>">
+          data-tt-id="<%= path %>"
+          data-tt-parent-id="<%= parent %>"
+          data-tt-branch="<%= file.container? ? 'true' : 'false' %>">
 
         <td role="gridcell" title="<%= file.name %>" class="<%=file.container? ? 'ev-container' : 'ev-file'%> ev-file-name">
           <% if disabled %>

--- a/lib/browse_everything/driver/file_system.rb
+++ b/lib/browse_everything/driver/file_system.rb
@@ -15,7 +15,7 @@ module BrowseEverything
         relative_path = path.sub(%r{^[\/.]+}, '')
         real_path = File.join(config[:home], relative_path)
         entries = if File.directory?(real_path)
-                    make_directory_entry(relative_path, real_path)
+                    make_directory_entry real_path
                   else
                     [details(real_path)]
                   end
@@ -34,7 +34,7 @@ module BrowseEverything
       end
 
       def details(path, display = File.basename(path))
-        return nil unless File.exist?(path)
+        return nil unless File.exist? path
         info = File::Stat.new(path)
         BrowseEverything::FileEntry.new(
           make_pathname(path),
@@ -48,9 +48,8 @@ module BrowseEverything
 
       private
 
-        def make_directory_entry(relative_path, real_path)
+        def make_directory_entry(real_path)
           entries = []
-          entries << details(File.expand_path('..', real_path), '..') if relative_path.present?
           entries + Dir[File.join(real_path, '*')].collect { |f| details(f) }
         end
 

--- a/spec/unit/browse_everything/driver/file_system_spec.rb
+++ b/spec/unit/browse_everything/driver/file_system_spec.rb
@@ -58,20 +58,14 @@ describe BrowseEverything::Driver::FileSystem do
     context 'when there is a subdirectory' do
       let(:contents) { provider.contents('/dir_1') }
 
-      context 'when referencing a parent directory' do
-        subject { contents[0] }
-
-        its(:name) { is_expected.to eq('..') }
-        specify    { is_expected.to be_container }
-      end
       context 'when there is a directory' do
-        subject { contents[1] }
+        subject { contents.first }
 
         its(:name) { is_expected.to eq('dir_3') }
         specify    { is_expected.to be_container }
       end
       context 'when there is a text file' do
-        subject { contents[2] }
+        subject { contents.last }
 
         its(:name)     { is_expected.to eq('file_2.txt') }
         its(:location) { is_expected.to eq("file_system:#{File.join(home, 'dir_1/file_2.txt')}") }


### PR DESCRIPTION
This was found to break the treetable jQuery plugin within a Valkyrie repository integrating this Gem.  As the relative paths for parent directories are redundant (the directories to which these resolve are also featured on the interface), this only affects the usability of the interface