### PR TITLE
example providers yaml should not use symbols

### DIFF
--- a/lib/generators/browse_everything/templates/browse_everything_providers.yml.example
+++ b/lib/generators/browse_everything/templates/browse_everything_providers.yml.example
@@ -13,7 +13,7 @@
 #   client_secret: YOUR_GOOGLE_API_CLIENT_SECRET
 # s3:
 #   bucket: YOUR_AWS_S3_BUCKET
-#   response_type: :signed_url # set to :public_url for public urls or :s3_uri for an s3://BUCKET/KEY uri
+#   response_type: signed_url # set to :public_url for public urls or :s3_uri for an s3://BUCKET/KEY uri
 #   expires_in: 14400 # for signed_url response_type, number of seconds url will be valid for.
 #   app_key: YOUR_AWS_S3_KEY       # :app_key, :app_secret, and :region can be specified
 #   app_secret: YOUR_AWS_S3_SECRET # explicitly here, or left out to use system-configured


### PR DESCRIPTION
Under at least some versions of ruby you will get a:

    /Users/jrochkind/.rubies/ruby-2.3.1/lib/ruby/2.3.0/psych/class_loader.rb:97:in `find': Tried to load unspecified class: Symbol (Psych::DisallowedClass)
   ....
    from /Users/jrochkind/.rubies/ruby-2.3.1/lib/ruby/2.3.0/psych.rb:302:in `safe_load'
    from /Users/jrochkind/code/browse-everything/lib/browse_everything.rb:56:in `configure'

from having a raw symbol in Yaml. Commit a9ec7df0cfb10ea removed symbols
from yaml _keys_ in browse_everything_providers.yml.example, perhaps for this reason (or not, there are no relevant comments on commit), but retained the :signed_url as a value. Which still causes that safe Yaml error, safe yaml does not like symbols.

Changing it to a string seems to work fine, without causing that problem.