### PR TITLE
s3 driver includes file_name in link_for extras

### DIFF
--- a/lib/browse_everything/driver/s3.rb
+++ b/lib/browse_everything/driver/s3.rb
@@ -61,11 +61,19 @@ module BrowseEverything
 
       def link_for(path)
         obj = bucket.object(full_path(path))
-        case config[:response_type].to_sym
-        when :signed_url then obj.presigned_url(:get, expires_in: config[:expires_in])
-        when :public_url then obj.public_url
-        when :s3_uri     then "s3://#{obj.bucket_name}/#{obj.key}"
-        end
+
+        extras = {
+          file_name: File.basename(path),
+          expires: (config[:expires_in] if config[:response_type] == :signed_url)
+        }.compact
+
+        url = case config[:response_type].to_sym
+              when :signed_url then obj.presigned_url(:get, expires_in: config[:expires_in])
+              when :public_url then obj.public_url
+              when :s3_uri     then "s3://#{obj.bucket_name}/#{obj.key}"
+              end
+
+        [url, extras]
       end
 
       def authorized?

--- a/spec/unit/browse_everything/driver/s3_spec.rb
+++ b/spec/unit/browse_everything/driver/s3_spec.rb
@@ -133,17 +133,17 @@ describe BrowseEverything::Driver::S3 do
 
         it ':signed_url' do
           provider.config[:response_type] = :signed_url
-          expect(provider.link_for('foo/quux.png')).to eq('https://s3.amazonaws.com/presigned_url')
+          expect(provider.link_for('foo/quux.png')).to eq ["https://s3.amazonaws.com/presigned_url", {:file_name=>"quux.png", :expires=>14400}]
         end
 
         it ':public_url' do
           provider.config[:response_type] = :public_url
-          expect(provider.link_for('foo/quux.png')).to eq('https://s3.amazonaws.com/public_url')
+          expect(provider.link_for('foo/quux.png')).to eq ["https://s3.amazonaws.com/public_url", {:file_name=>"quux.png"}]
         end
 
         it ':s3_uri' do
           provider.config[:response_type] = :s3_uri
-          expect(provider.link_for('foo/quux.png')).to eq('s3://s3.bucket/foo/quux.png')
+          expect(provider.link_for('foo/quux.png')).to eq ['s3://s3.bucket/foo/quux.png', {:file_name=>"quux.png"}]
         end
       end
     end


### PR DESCRIPTION
Some client code expects this, such as [sufia](https://github.com/samvera/sufia/blob/63e3f1338fb409b7854491ab3c9467209e009aa6/app/assets/javascripts/sufia/browse_everything.js) and (identical) [hyrax](https://github.com/samvera/hyrax/blob/0fe39d4f4dcc24deb805c1e66527ac^C9df7741a/app/assets/javascripts/hyrax/browse_everything.js).

In sufia/hyrax if the filename isn't there, it ends up blank in the UI.

I also added the expires header (where applicable), because I noticed that the [box driver](https://github.com/samvera/browse-everything/blob/2c0a3447049f7ee925a0ee0759d246fa28c474ac/lib/browse_everything/driver/box.rb#L59) has it, so I figured it couldn't hurt, although I am not aware of client code using it.

The sufia/hyrax client code REALLY wants a `size` key as well, but there doesn't seem to be a way to get it in the current architecture without another S3 API call. The size was already there displayed in the listing, so it's already been fetched, and there ought to be a way for the client code to get it... but I can't figure out what it is, so punting on that for now.