### PR TITLE
Implementing error handling for cases where HTTParty retrieves a response with a non-200 status code for downloads

### DIFF
--- a/lib/browse_everything/retriever.rb
+++ b/lib/browse_everything/retriever.rb
@@ -1,17 +1,44 @@
 # frozen_string_literal: true
 
+require 'addressable'
 require 'httparty'
 require 'tempfile'
-require 'addressable'
 
 module BrowseEverything
-  class Retriever
-    attr_accessor :chunk_size
+  # Class for raising errors when a download is invalid
+  # @see HTTParty::Error
+  class DownloadError < HTTParty::Error
+    attr_reader :response
 
-    def initialize
-      @chunk_size = 16384
+    # Constructor
+    # @param msg [String]
+    # @param response [HTTParty::Response] response from the server
+    def initialize(msg, response)
+      @response = response
+      super(msg)
     end
 
+    # Generate the message for the exception
+    # @return [String]
+    def message
+      "#{super}: #{response.body}"
+    end
+  end
+
+  # Class for retrieving a file or resource from a storage provider
+  class Retriever
+    CHUNK_SIZE = 16384
+
+    attr_accessor :chunk_size
+
+    # Constructor
+    def initialize
+      @chunk_size = CHUNK_SIZE
+    end
+
+    # Download a file or resource
+    # @param options [Hash]
+    # @param target [String, nil] system path to the downloaded file (defaults to a temporary file)
     def download(spec, target = nil)
       if target.nil?
         ext = File.extname(spec['file_name'])
@@ -28,63 +55,102 @@ module BrowseEverything
       target
     end
 
-    def retrieve(spec, &block)
-      raise ArgumentError, "Download spec expired at #{spec['expires']}" if spec.key?('expires') && Time.parse(spec['expires']) < Time.now
+    # Retrieve the resource from the storage service
+    # @param options [Hash]
+    def retrieve(options, &block)
+      expiry_time_value = options.fetch('expires', nil)
+      if expiry_time_value
+        expiry_time = Time.parse(expiry_time_value)
+        raise ArgumentError, "Download expired at #{expiry_time}" if expiry_time < Time.now
+      end
 
-      parsed_spec = parse_spec(spec)
+      download_options = extract_download_options(options)
+      url = download_options.fetch(:url)
 
-      case parsed_spec[:url].scheme
+      case url.scheme
       when 'file'
-        retrieve_file(parsed_spec, &block)
+        retrieve_file(download_options, &block)
       when /https?/
-        retrieve_http(parsed_spec, &block)
+        retrieve_http(download_options, &block)
       else
-        raise URI::BadURIError, "Unknown URI scheme: #{parsed_spec[:url].scheme}"
+        raise URI::BadURIError, "Unknown URI scheme: #{url.scheme}"
       end
     end
 
     private
 
-      def parse_spec(spec)
-        result = {
-          url: ::Addressable::URI.parse(spec['url']),
-          headers: spec['auth_header'] || {},
-          file_size: spec.fetch('file_size', 0).to_i
+      # Extract and parse options used to download a file or resource from an HTTP API
+      # @param options [Hash]
+      # @return [Hash]
+      def extract_download_options(options)
+        url = options.fetch('url')
+
+        # This avoids the potential for a KeyError
+        headers = options.fetch('auth_header', {}) || {}
+        headers.each_pair { |k, v| headers[k] = v.tr('+', ' ') }
+
+        file_size_value = options.fetch('file_size', 0)
+        file_size = file_size_value.to_i
+
+        output = {
+          url: ::Addressable::URI.parse(url),
+          headers: headers,
+          file_size: file_size
         }
 
-        result[:headers].each_pair { |k, v| result[:headers][k] = v.tr('+', ' ') }
-        result[:file_size] = get_file_size(result) if result[:file_size] < 1
-        result
+        output[:file_size] = get_file_size(output) if output[:file_size] < 1
+        output
       end
 
-      def retrieve_file(parsed_spec)
+      # Retrieve the file from the file system
+      # @param options [Hash]
+      def retrieve_file(options)
+        file_uri = options.fetch(:url)
+        file_size = options.fetch(:file_size)
+
         retrieved = 0
-        File.open(parsed_spec[:url].path, 'rb') do |f|
+        File.open(file_uri.path, 'rb') do |f|
           until f.eof?
             chunk = f.read(chunk_size)
             retrieved += chunk.length
-            yield(chunk, retrieved, parsed_spec[:file_size])
+            yield(chunk, retrieved, file_size)
           end
         end
       end
 
-      def retrieve_http(parsed_spec)
+      # Retrieve a resource over the HTTP
+      # @param options [Hash]
+      def retrieve_http(options)
+        file_size = options.fetch(:file_size)
+        headers = options.fetch(:headers)
+        url = options.fetch(:url)
         retrieved = 0
-        stream_body = parsed_spec[:file_size] > 500.megabytes
 
-        HTTParty.get(parsed_spec[:url].to_s, stream_body: stream_body, headers: parsed_spec[:headers]) do |chunk|
+        # Determine whether or not to stream the body by the size of the resource requested
+        stream_body = file_size > 500.megabytes
+
+        response = HTTParty.get(url.to_s, stream_body: stream_body, headers: headers) do |chunk|
           retrieved += chunk.length
-          yield(chunk, retrieved, parsed_spec[:file_size])
+          yield(chunk, retrieved, file_size)
         end
+        raise DownloadError.new("#{self.class}: Failed to download #{url}", response) unless response.code == 200
       end
 
-      def get_file_size(parsed_spec)
-        case parsed_spec[:url].scheme
+      # Retrieve the file size
+      # @param options [Hash]
+      # @return [Integer] the size of the requested file
+      def get_file_size(options)
+        url = options.fetch(:url)
+        headers = options.fetch(:headers)
+        file_size = options.fetch(:file_size)
+
+        case url.scheme
         when 'file'
           File.size(url.path)
         when /https?/
-          response = HTTParty.head(parsed_spec[:url].to_s, headers: parsed_spec[:headers])
-          (response.content_length || parsed_spec[:file_size]).to_i
+          response = HTTParty.head(url.to_s, headers: headers)
+          length_value = response.content_length || file_size
+          length_value.to_i
         else
           raise URI::BadURIError, "Unknown URI scheme: #{url.scheme}"
         end


### PR DESCRIPTION
For handling cases where `HTTParty` responses with status codes other than 200 (as this led to problems in which error messages from cloud providers were saved as binary file content)