### PR TITLE
[WIP] Restricting the scope of the Google API client in order to avoid App verification errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 dist: trusty
 sudo: required
 addons:
@@ -10,7 +9,6 @@ cache:
 before_install:
   - gem update --system # https://docs.travis-ci.com/user/languages/ruby/#Upgrading-RubyGems
   - gem install bundler
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 
 rvm:
   - 2.4.3

--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'capybara'
-  spec.add_development_dependency 'chromedriver-helper'
+  spec.add_development_dependency 'chromedriver-helper', '~> 1.2'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'engine_cart', '~> 1.0'
   spec.add_development_dependency 'factory_bot_rails'
@@ -47,7 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'rubocop', '~> 0.53'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.23'
-  spec.add_development_dependency 'selenium-webdriver'
+  spec.add_development_dependency 'selenium-webdriver', '~> 3.13'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'vcr'

--- a/lib/browse_everything/driver/google_drive.rb
+++ b/lib/browse_everything/driver/google_drive.rb
@@ -206,8 +206,12 @@ module BrowseEverything
           Tempfile.new('gdrive.yaml')
         end
 
+        # Specifies the scope for the OAuth client interfacing with Google
+        # Services
+        # @see https://developers.google.com/drive/api/v3/about-auth#what_scope_or_scopes_does_my_app_need
+        # @return [String] the scope
         def scope
-          Google::Apis::DriveV3::AUTH_DRIVE
+          Google::Apis::DriveV3::AUTH_DRIVE_READONLY
         end
 
         # Provides the user ID for caching access tokens

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -5,13 +5,22 @@ require 'selenium-webdriver'
 Capybara.javascript_driver = :headless_chrome
 
 Capybara.register_driver :headless_chrome do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless disable-gpu no-sandbox] }
-  )
+  options = Selenium::WebDriver::Chrome::Options.new
 
+  options.add_argument('--headless')
+  options.add_argument('--disable-gpu')
+  options.add_argument('--no-sandbox')
+  options.add_argument('--disable-dev-shm-usage')
+  options.add_argument('--start-maximized')
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,
-                                 desired_capabilities: capabilities)
+                                 options: options)
 end
 
 Capybara.default_max_wait_time = 5
+
+RSpec.configure do |config|
+  config.before(:each, type: :system, js: true) do
+    driven_by :headless_chrome
+  end
+end

--- a/spec/unit/browse_everything/driver/google_drive_spec.rb
+++ b/spec/unit/browse_everything/driver/google_drive_spec.rb
@@ -156,7 +156,7 @@ describe BrowseEverything::Driver::GoogleDrive, vcr: { cassette_name: 'google_dr
 
       it 'exposes the authorization endpoint URI' do
         expect(uri).to be_a Addressable::URI
-        expect(uri.to_s).to eq 'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force&client_id=CLIENTID&include_granted_scopes=true&redirect_uri=http://example.com:3000/browse/connect&response_type=code&scope=https://www.googleapis.com/auth/drive'
+        expect(uri.to_s).to eq 'https://accounts.google.com/o/oauth2/auth?access_type=offline&approval_prompt=force&client_id=CLIENTID&include_granted_scopes=true&redirect_uri=http://example.com:3000/browse/connect&response_type=code&scope=https://www.googleapis.com/auth/drive.readonly'
       end
     end
 


### PR DESCRIPTION
Google API access is now more strictly controlled in response to the General Data Protection Regulation (GDPR):
https://services.google.com/fh/files/misc/google_cloud_and_the_gdpr_english.pdf

With proper configuration using Google Cloud Identity, clients should no longer issue a warning when users provide repositories with access to Google Drive resources
