### PR TITLE
Replace HTTParty with Typhoeus for improved large file streaming support

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'font-awesome-rails'
   spec.add_dependency 'google-api-client', '~> 0.21'
   spec.add_dependency 'google_drive', '~> 2.1'
-  spec.add_dependency 'httparty', '~> 0.15'
+  spec.add_dependency 'typhoeus'
   spec.add_dependency 'rails', '>= 4.2'
   spec.add_dependency 'ruby-box'
   spec.add_dependency 'sass-rails'

--- a/spec/fixtures/vcr_cassettes/retriever.yml
+++ b/spec/fixtures/vcr_cassettes/retriever.yml
@@ -2,6 +2,99 @@
 http_interactions:
 - request:
     method: get
+    uri: https://retrieve.cloud.example.com/some/dir/can_retrieve.pdf
+    headers:
+      Range: bytes=0-0
+  response:
+    status:
+      code: '206'
+      message: 'Partial Content'
+    headers:
+      Content-Length:
+      - 1
+      Content-Type:
+      - application/pdf
+      Content-Range:
+      - 'bytes 0-0/64134'
+    body:
+      encoding: ASCII-8BIT
+      string: '%'
+    http_version: '1.1'
+  recorded_at: Tue, 24 Jul 2018 10:38:42 GMT
+- request:
+    method: get
+    uri: https://retrieve.cloud.example.com/some/dir/cannot_retrieve.pdf
+    headers:
+      Range: bytes=0-0
+  response:
+    status:
+      code: '403'
+      message: 'Unauthorized'
+    http_version: '1.1'
+  recorded_at: Tue, 24 Jul 2018 10:38:42 GMT
+- request:
+    method: get
+    uri: https://drive.google.com/uc?export=download&id=id
+    headers:
+      Authorization:
+      - Bearer access-token
+  response:
+    status:
+      code: '200'
+      message: OK
+    headers:
+      Content-Length: '1234'
+    body:
+      encoding: ASCII-8BIT
+      string: content
+    http_version: '1.1'
+  recorded_at: Mon, 23 Jul 2018 16:00:03 GMT
+- request:
+    method: head
+    uri: https://drive.google.com/uc?export=download&id=id
+    headers:
+      Authorization:
+      - Bearer access-token
+  response:
+    status:
+      code: '200'
+      message: OK
+    headers:
+      Content-Length: '1234'
+    body:
+      encoding: ASCII-8BIT
+      string: content
+    http_version: '1.1'
+  recorded_at: Mon, 23 Jul 2018 16:00:03 GMT
+- request:
+    method: get
+    uri: https://retrieve.cloud.example.com/some/dir/file_error.pdf
+    headers:
+      Accept: ! '*/*'
+      Authorization: Bearer ya29.kQCEAHj1bwFXr2AuGQJmSGRWQXpacmmYZs4kzCiXns3d6H1ZpIDWmdM8
+  response:
+    status:
+      code: '403'
+      message: Unauthorized
+    headers:
+      Server: nginx
+      Date: Wed, 01 Oct 2014 14:01:16 GMT
+      Content-Type: application/json
+      Transfer-Encoding: chunked
+      Connection: close
+      pragma: no-cache
+      cache-control: no-cache
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {"error":{"errors":[{"domain":"usageLimits","reason":"dailyLimitExceededUnreg",
+        "message":"Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup.",
+        "extendedHelp":"https://code.google.com/apis/console"}],"code":403,
+        "message":"Daily Limit for Unauthenticated Use Exceeded. Continued use requires signup."}}
+    http_version: '1.1'
+  recorded_at: Mon, 23 Jul 2018 15:27:31 GMT
+- request:
+    method: get
     uri: https://retrieve.cloud.example.com/some/dir/file.pdf
     headers:
       Accept: ! '*/*'


### PR DESCRIPTION
`BrowseEverything::Retriever` can experience out of memory errors when retrieving large files, even in chunked mode. `HTTParty`'s documentation clearly states that it's intended for small XML/JSON payloads and isn't designed for streaming. This PR replaces `HTTParty` with the much more robust and flexible [`Typhoeus`](https://github.com/typhoeus/typhoeus) HTTP library for improved speed and memory performance. The external interface to `BrowseEverything::Retriever` is unchanged.