### PR TITLE
Allow browse_everything_providers.yml to contain symbols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ test/tmp
 test/version_tmp
 tmp
 .internal_test_app
-browse_everything_providers.yml

--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'font-awesome-rails'
   spec.add_dependency 'google-api-client', '~> 0.21'
   spec.add_dependency 'google_drive', '~> 2.1'
+  spec.add_dependency 'googleauth', '0.6.2'
   spec.add_dependency 'rails', '>= 4.2'
   spec.add_dependency 'ruby-box'
   spec.add_dependency 'sass-rails'

--- a/lib/browse_everything.rb
+++ b/lib/browse_everything.rb
@@ -53,7 +53,7 @@ module BrowseEverything
       elsif value.is_a?(String)
         config_file_content = File.read(value)
         config_file_template = ERB.new(config_file_content)
-        config_values = YAML.safe_load(config_file_template.result)
+        config_values = YAML.safe_load(config_file_template.result, [Symbol])
         @config = ActiveSupport::HashWithIndifferentAccess.new config_values
         @config.deep_symbolize_keys
       else

--- a/spec/fixtures/config/browse_everything_providers.yml
+++ b/spec/fixtures/config/browse_everything_providers.yml
@@ -1,0 +1,10 @@
+---
+:dropbox:
+  :app_key: test-key
+  :app_secret: test-secret
+:box:
+  :client_id: test-id
+  :client_secret: test-secret
+:google_drive:
+  :client_id: test-id
+  :client_secret: test-secret

--- a/spec/lib/browse_everything_spec.rb
+++ b/spec/lib/browse_everything_spec.rb
@@ -1,60 +1,76 @@
 # frozen_string_literal: true
 
 describe BrowseEverything do
+  shared_examples "a configured BrowseEverything module" do
+    describe 'registered configuration' do
+      it 'registers the configuration for the drivers' do
+        expect(described_class.config).to be_a ActiveSupport::HashWithIndifferentAccess
+
+        expect(described_class.config).to include 'dropbox'
+        expect(described_class.config['dropbox']).to include('app_key' => 'test-key')
+        expect(described_class.config['dropbox']).to include('app_secret' => 'test-secret')
+
+        expect(described_class.config).to include 'box'
+        expect(described_class.config['box']).to include('client_id' => 'test-id')
+        expect(described_class.config['box']).to include('client_secret' => 'test-secret')
+
+        expect(described_class.config).to include 'google_drive'
+        expect(described_class.config['google_drive']).to include('client_id' => 'test-id')
+        expect(described_class.config['google_drive']).to include('client_secret' => 'test-secret')
+      end
+    end
+  end
+
   describe '.configure' do
-    let(:config) do
-      {
-        dropbox: {
-          app_key: 'test-key',
-          app_secret: 'test-secret'
-        },
-        box: {
-          client_id: 'test-id',
-          client_secret: 'test-secret'
-        },
-        google_drive: {
-          client_id: 'test-id',
-          client_secret: 'test-secret'
-        }
-      }
-    end
-
-    before do
-      described_class.configure(config)
-    end
-
-    it 'registers the configuration for the drivers' do
-      expect(described_class.config).to be_a ActiveSupport::HashWithIndifferentAccess
-
-      expect(described_class.config).to include 'dropbox'
-      expect(described_class.config['dropbox']).to include('app_key' => 'test-key')
-      expect(described_class.config['dropbox']).to include('app_secret' => 'test-secret')
-
-      expect(described_class.config).to include 'box'
-      expect(described_class.config['box']).to include('client_id' => 'test-id')
-      expect(described_class.config['box']).to include('client_secret' => 'test-secret')
-
-      expect(described_class.config).to include 'google_drive'
-      expect(described_class.config['google_drive']).to include('client_id' => 'test-id')
-      expect(described_class.config['google_drive']).to include('client_secret' => 'test-secret')
-    end
-
-    context 'with an entry for the drop_box provider' do
+    context 'with a hash' do
       let(:config) do
         {
-          drop_box: {
+          dropbox: {
             app_key: 'test-key',
             app_secret: 'test-secret'
+          },
+          box: {
+            client_id: 'test-id',
+            client_secret: 'test-secret'
+          },
+          google_drive: {
+            client_id: 'test-id',
+            client_secret: 'test-secret'
           }
         }
       end
 
-      it 'logs a deprecation warning and sets it to the dropbox key' do
-        expect(described_class.config).not_to include 'drop_box'
-        expect(described_class.config).to include 'dropbox'
-        expect(described_class.config['dropbox']).to include('app_key' => 'test-key')
-        expect(described_class.config['dropbox']).to include('app_secret' => 'test-secret')
+      before do
+        described_class.configure(config)
       end
+
+      it_behaves_like 'a configured BrowseEverything module'
+
+      context 'with an entry for the drop_box provider' do
+        let(:config) do
+          {
+            drop_box: {
+              app_key: 'test-key',
+              app_secret: 'test-secret'
+            }
+          }
+        end
+
+        it 'logs a deprecation warning and sets it to the dropbox key' do
+          expect(described_class.config).not_to include 'drop_box'
+          expect(described_class.config).to include 'dropbox'
+          expect(described_class.config['dropbox']).to include('app_key' => 'test-key')
+          expect(described_class.config['dropbox']).to include('app_secret' => 'test-secret')
+        end
+      end
+    end
+
+    context 'with a YAML file' do
+      before do
+        described_class.configure(File.expand_path('../../fixtures/config/browse_everything_providers.yml', __FILE__))
+      end
+
+      it_behaves_like 'a configured BrowseEverything module'
     end
   end
 


### PR DESCRIPTION
Add shared config example to specs