### PR TITLE
Ensures that the deprecated config. setting :signed_url for the S3 driver is properly mapped to a :response_type value, and defaults to :signed_url

### DIFF
--- a/lib/browse_everything/driver/s3.rb
+++ b/lib/browse_everything/driver/s3.rb
@@ -21,9 +21,10 @@ module BrowseEverything
       attr_reader :entries
 
       def initialize(config, *args)
-        if config.key?(:signed_url) && config.delete(:signed_url) == false
-          warn '[DEPRECATION] Amazon S3 driver: `:signed_url` is deprecated.  Please use `:response_type` instead.'
-          config[:response_type] = :public_url
+        if config.key?(:signed_url)
+          warn '[DEPRECATION] Amazon S3 driver: `:signed_url` is deprecated.  Please use `response_type :signed_url` instead.'
+          response_type = config.delete(:signed_url) ? :signed_url : :public_url
+          config[:response_type] = response_type
         end
         merged_config = DEFAULTS.merge(config)
         self.class.authentication_klass ||= self.class.default_authentication_klass

--- a/spec/lib/browse_everything/driver/s3_spec.rb
+++ b/spec/lib/browse_everything/driver/s3_spec.rb
@@ -46,10 +46,22 @@ describe BrowseEverything::Driver::S3 do
       expect { described_class.new(bucket: 'bucket', region: 'us-east-1', response_type: :foo) }.to raise_error(BrowseEverything::InitializationError)
     end
 
-    it 'deprecates :signed_url' do
-      driver = described_class.new(bucket: 'bucket', region: 'us-east-1', signed_url: false)
-      expect(driver.config).not_to have_key(:signed_url)
-      expect(driver.config[:response_type]).to eq(:public_url)
+    context 'deprecating :signed_url' do
+      it 'sets the value of :signed_url to :response_type' do
+        driver = described_class.new(bucket: 'bucket', region: 'us-east-1', signed_url: false)
+        expect(driver.config).not_to have_key(:signed_url)
+        expect(driver.config[:response_type]).to eq(:public_url)
+
+        signed_driver = described_class.new(bucket: 'bucket', region: 'us-east-1', signed_url: true)
+        expect(signed_driver.config).not_to have_key(:signed_url)
+        expect(signed_driver.config[:response_type]).to eq(:signed_url)
+      end
+
+      it 'sets the default value of :response_type to :signed_url' do
+        driver = described_class.new(bucket: 'bucket', region: 'us-east-1')
+        expect(driver.config).not_to have_key(:signed_url)
+        expect(driver.config[:response_type]).to eq(:signed_url)
+      end
     end
   end
 


### PR DESCRIPTION
Resolves #239 