### PR TITLE
Fixes Typhoeus::Request request bugs (found in testing against Hyrax); Releases 1.0.0

### DIFF
--- a/lib/browse_everything/driver/box.rb
+++ b/lib/browse_everything/driver/box.rb
@@ -68,7 +68,7 @@ module BrowseEverything
 
       # @return [Hash]
       # Gets the appropriate tokens from Box using the access code returned from :auth_link:
-      def connect(params, _data)
+      def connect(params, _data, _url_options)
         register_access_token(box_session.get_access_token(params[:code]))
       end
 

--- a/lib/browse_everything/driver/google_drive.rb
+++ b/lib/browse_everything/driver/google_drive.rb
@@ -175,7 +175,7 @@ module BrowseEverything
       # @param params [Hash] HTTP response passed to the OAuth callback
       # @param _data [Object,nil] an unused parameter
       # @return [String] a new access token
-      def connect(params, _data)
+      def connect(params, _data, _url_options)
         @code = params[:code]
         authorize!
       end

--- a/lib/browse_everything/retriever.rb
+++ b/lib/browse_everything/retriever.rb
@@ -70,7 +70,7 @@ module BrowseEverything
       end
 
       download_options = extract_download_options(options)
-      url = download_options.fetch(:url)
+      url = download_options[:url]
 
       case url.scheme
       when 'file'
@@ -91,8 +91,7 @@ module BrowseEverything
         url = options.fetch('url')
 
         # This avoids the potential for a KeyError
-        headers = options.fetch('auth_header', {}) || {}
-        headers.each_pair { |k, v| headers[k] = v.tr('+', ' ') }
+        headers = options.fetch('headers', {}) || {}
 
         file_size_value = options.fetch('file_size', 0)
         file_size = file_size_value.to_i
@@ -131,9 +130,9 @@ module BrowseEverything
         url = options.fetch(:url)
         retrieved = 0
 
-        request = Typhoeus::Request.new(url.to_s, headers: headers)
+        request = Typhoeus::Request.new(url.to_s, method: :get, headers: headers)
         request.on_headers do |response|
-          raise DownloadError.new("#{self.class}: Failed to download #{url}", response) unless response.code == 200
+          raise DownloadError.new("#{self.class}: Failed to download #{url}: Status Code: #{response.code}", response) unless response.code == 200
         end
         request.on_body do |chunk|
           retrieved += chunk.bytesize

--- a/lib/browse_everything/version.rb
+++ b/lib/browse_everything/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrowseEverything
-  VERSION = '0.16.1'
+  VERSION = '1.0.0'
 end

--- a/spec/lib/browse_everything/driver/box_spec.rb
+++ b/spec/lib/browse_everything/driver/box_spec.rb
@@ -90,7 +90,7 @@ describe BrowseEverything::Driver::Box do
     end
 
     it 'registers new tokens' do
-      provider.connect(auth_params, 'data')
+      provider.connect(auth_params, 'data', nil)
       expect(provider).to have_received(:register_access_token).with(kind_of(OAuth2::AccessToken))
     end
   end

--- a/spec/lib/browse_everything/driver/google_drive_spec.rb
+++ b/spec/lib/browse_everything/driver/google_drive_spec.rb
@@ -87,7 +87,7 @@ describe BrowseEverything::Driver::GoogleDrive do
     let(:driver) { described_class.new(provider_yml) }
 
     before do
-      driver.connect({ code: 'code' }, {})
+      driver.connect({ code: 'code' }, {}, nil)
     end
 
     describe '#authorized?' do

--- a/spec/lib/browse_everything/retriever_spec.rb
+++ b/spec/lib/browse_everything/retriever_spec.rb
@@ -12,7 +12,7 @@ describe BrowseEverything::Retriever do
     subject(:computed_file_size) { retriever.file_size(options) }
 
     let(:url) { URI.parse("file://#{datafile}") }
-    let(:headers) { [] }
+    let(:headers) { {} }
     let(:file_size) { 0 }
     let(:options) do
       {


### PR DESCRIPTION
After testing against the latest `master` branch of Hyrax, this addressing the following errors:
* Fixing a bug for #connect parameters
* Fixing Typhoeus::Request construction and error handling
* Fixing integration bugs with Google Drive headers, Typhoeus, and Retriever
* Fixes the Dropbox provider
* Releases 1.0.0

This currently blocks https://github.com/samvera/hyrax/pull/3348.  **Please refer to the Hyrax pull request in order to test all providers before merging this**