### PR TITLE
remove explicit sass-rails dependency

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'googleauth', '0.6.6'
   spec.add_dependency 'rails', '>= 4.2'
   spec.add_dependency 'ruby-box'
-  spec.add_dependency 'sass-rails'
   spec.add_dependency 'signet', '~> 0.8'
   spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'typhoeus'


### PR DESCRIPTION
A Rails app is generated with a sass-rails dependency, so no changes to tests were needed -- the engine-cart-generated test app adds it's own sass-rails dependency.

While current Rails releases generate with sass-rails dependency, sass-rails is sunsetted/deprecated, due to the underlying pure-ruby ruby-sass gem being deprecated, and instructs "consider switching to the sassc gem"  https://github.com/sass/ruby-sass .

Rails 6.0 will perhaps depend on the sassc-rails gem instead, or perhaps the sass-rails gem itself will be changed to depend on sassc instead of sass-ruby. I am not sure if it is yet determined/done. https://github.com/rails/rails/issues/3289

But apps now may wish to switch to sassc-rails, especially if it's a new app. While sassc-rails _ought_ to be a drop-in replacement, bugs can happen, and the timeline of switching (or refraining from switching) should be up to a dependent app.  However, if an app depends on both sass-rails and sassc-rails, problems can occur. https://github.com/sass/sassc-rails/issues/6

So, removing the sass-rails as an explicit dependency from browse-everything will allow dependent apps to choose sass-rails or sassc-rails themselves, switching on their own timeline, without the browse-everything dependency interfering. This change is unlikely to pose any backwards compatibility problems, as dependent apps should have sass-rails in their Gemfile already, as it is generated by Rails. In the unlikely event some dependent app did not have sass-rails independently declared as a dependency, however, they would have to add it.

Ref #246 