### PR TITLE
Runs tests against Ruby releases 2.6.1, 2.5.3, 2.4.5, and 2.3.8 and ensures that Travis CI builds downgrade Bundler from 2.x releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,16 @@ cache:
 
 before_install:
   - gem update --system # https://docs.travis-ci.com/user/languages/ruby/#Upgrading-RubyGems
-  - gem install bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
   - npm install -g karma karma-jasmine karma-chrome-launcher
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 
 rvm:
-  - 2.5.1
-  - 2.4.4
-  - 2.3.7
+  - 2.6.1
+  - 2.5.3
+  - 2.4.5
+  - 2.3.8
 
 env:
   global:


### PR DESCRIPTION
Derived from #261 