### PR TITLE
Supporting Rails 5.1.z releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,6 @@ workflows:
           name: "ruby2-7_rails5-1"
           ruby_version: 2.7.0
           rails_version: 5.1.7
-
       - build:
           name: "ruby2-6_rails6-0"
           ruby_version: 2.6.5
@@ -79,7 +78,6 @@ workflows:
           name: "ruby2-6_rails5-1"
           ruby_version: 2.6.5
           rails_version: 5.1.7
-
       - build:
           name: "ruby2-5_rails6-0"
           ruby_version: 2.5.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,10 +63,6 @@ workflows:
           ruby_version: 2.7.0
           rails_version: 5.2.4
       - build:
-          name: "ruby2-7_rails5-1"
-          ruby_version: 2.7.0
-          rails_version: 5.1.7
-      - build:
           name: "ruby2-6_rails6-0"
           ruby_version: 2.6.5
           rails_version: 6.0.2

--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'googleauth', '0.6.6'
   spec.add_dependency 'jsonapi-resources'
   spec.add_dependency 'puma', '>= 3.11'
-  spec.add_dependency 'rails', '>= 5.2' # We're going to need to require support for webpacker given the usage of rswag-ui to generate Swagger documentation
+  spec.add_dependency 'rails', '>= 5.1' # We're going to need to require support for webpacker given the usage of rswag-ui to generate Swagger documentation
   spec.add_dependency 'rswag', '2.0.6' # Blocked until 2.1.z resolved https://github.com/rswag/rswag/issues/248
   spec.add_dependency 'ruby-box'
   spec.add_dependency 'signet', '~> 0.8'

--- a/db/migrate/20190905134421_create_session_models.rb
+++ b/db/migrate/20190905134421_create_session_models.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateSessionModels < ActiveRecord::Migration[5.2]
+class CreateSessionModels < ActiveRecord::Migration[(Rails.version =~ /5.1/ ? 5.1 : 5.2)]
   def change
     create_table :session_models do |t|
       t.string :uuid

--- a/db/migrate/20190911121009_create_authorization_models.rb
+++ b/db/migrate/20190911121009_create_authorization_models.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateAuthorizationModels < ActiveRecord::Migration[5.2]
+class CreateAuthorizationModels < ActiveRecord::Migration[(Rails.version =~ /5.1/ ? 5.1 : 5.2)]
   def change
     create_table :authorization_models do |t|
       t.string :uuid

--- a/db/migrate/20190930132547_create_upload_models.rb
+++ b/db/migrate/20190930132547_create_upload_models.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateUploadModels < ActiveRecord::Migration[5.2]
+class CreateUploadModels < ActiveRecord::Migration[(Rails.version =~ /5.1/ ? 5.1 : 5.2)]
   def change
     create_table :upload_models do |t|
       t.string :uuid

--- a/db/migrate/20191004125901_create_upload_files.rb
+++ b/db/migrate/20191004125901_create_upload_files.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateUploadFiles < ActiveRecord::Migration[5.2]
+class CreateUploadFiles < ActiveRecord::Migration[(Rails.version =~ /5.1/ ? 5.1 : 5.2)]
   def change
     create_table :upload_files, &:timestamps
   end


### PR DESCRIPTION
This stabilizes the `next/rails-api/jrgriffiniii` branch with support for Rails 5.1.z releases.