### PR TITLE
Easing version restriction of Thor

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ruby-box'
   spec.add_dependency 'signet', '~> 0.8'
   spec.add_dependency 'sprockets', '~> 3.7'
-  spec.add_dependency 'thor', '~> 0.19'
+  spec.add_dependency 'thor', ">= 0.18.1", "< 2.0" # This matches the lower bounds of Rails 4.2.0 and upper bounds of Rails 5.2.4
   spec.add_dependency 'typhoeus'
 
   spec.add_development_dependency 'bixby', '>= 1.0'

--- a/lib/browse_everything/driver/dropbox.rb
+++ b/lib/browse_everything/driver/dropbox.rb
@@ -16,14 +16,14 @@ module BrowseEverything
         class << self
           private
 
-          def klass_for(metadata)
-            case metadata
-            when DropboxApi::Metadata::File
-              FileFactory
-            else
-              ResourceFactory
+            def klass_for(metadata)
+              case metadata
+              when DropboxApi::Metadata::File
+                FileFactory
+              else
+                ResourceFactory
+              end
             end
-          end
         end
       end
 


### PR DESCRIPTION
Prior to this commit, the version restriction of Thor was locked to a
version compatable the various Rails versions, but reflective of the
somewhat implicit fixing pre 1.0 gem dependencies to a narrow version.

With the release of Thor 1.0 and Rails adherance to these ranges, this
commit opts for adding an explicit version range. _Note: We could
remove the explicit dependency, and allow for the upstream Rails
dependency to take effect._

Closes #338