### PR TITLE
remove puma from .gemspec

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-api-client', '~> 0.23'
   spec.add_dependency 'google_drive', '~> 2.1'
   spec.add_dependency 'googleauth', '0.6.6'
-  spec.add_dependency 'puma', '~> 3.11'
   spec.add_dependency 'rails', '>= 4.2', '< 6.0'
   spec.add_dependency 'ruby-box'
   spec.add_dependency 'signet', '~> 0.8'


### PR DESCRIPTION
It's not actually a dependency of this gem; apps using this gem do not need puma installed, let alone a specific version of puma.

Past commit message at 0a9ed02 suggested puma was needed here for circle-ci to succeed, but let's see if that's still true.

Could resolve #337