### PR TITLE
Allow more recent googleauth

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dropbox_api', '>= 0.1.10'
   spec.add_dependency 'google-api-client', '~> 0.23'
   spec.add_dependency 'google_drive', '~> 2.1'
-  spec.add_dependency 'googleauth', '0.6.6'
+  spec.add_dependency 'googleauth', '>= 0.6.6', '< 1.0'
   spec.add_dependency 'rails', '>= 4.2', '< 6.0'
   spec.add_dependency 'ruby-box'
   spec.add_dependency 'signet', '~> 0.8'


### PR DESCRIPTION
In general, it's bad gem behavior to a lock to a very specific version. Prior, browse-everything was expressing the requirement that it would *only* work with googleauth 0.6.6. There is no way for a using app to use any older or any newer version, even if one comes out with a security patch etc.

0.6.6 is a pretty old version of googleauthi (Aug 2018, it's now up to 0.13), but browse-everything would not allow you to use a newer one. Which also meant that by transitive dependencies, you were stuck using faraday < 1.0 also, et al.

It is unfortunate that googleauth is still pre-1.0, so it's hard to count on semantic versioning. Still, looking at the [changelog](https://github.com/googleapis/google-auth-library-ruby/blob/master/CHANGELOG.md) of googleauth, it does not seem like any of the 0.x releases have involved backwards incompat changes. Hoping that our use of googleauth here is also probably pretty basic, and unlikely to break with future versions, we say we will allow any future versions up to 1.0, but not a future 1.0 -- we'll have to manually revisit for googleauth 1.0.

Resolves #336