### PR TITLE
Allow google_drive 3.x

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-s3'
   spec.add_dependency 'dropbox_api', '>= 0.1.10'
   spec.add_dependency 'google-api-client', '~> 0.23'
-  spec.add_dependency 'google_drive', '~> 2.1'
+  spec.add_dependency 'google_drive', '>= 2.1', "< 4"
   spec.add_dependency 'googleauth', '>= 0.6.6', '< 1.0'
   spec.add_dependency 'rails', '>= 4.2', '< 6.0'
   spec.add_dependency 'ruby-box'


### PR DESCRIPTION
google_drive 3.0 came out November 2018. https://rubygems.org/gems/google_drive/versions/

Prior to this change, any app using browse_everything would be prevented from using google_drive 3.0.

The backwards compat changes in google_drive 3.0 appear minimal and only related to "google sheets", which I don't believe browse_everything uses, so I believe it should Just Work to allow google_drive 3.0. If not, hopefully tests will catch it?

https://github.com/gimite/google-drive-ruby/blob/master/MIGRATING.md#migrating-from-version-2xx