### PR TITLE
Allow sprockets4 in gemspec, but installer injects sprockets3 requirement to local app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,10 @@ gemspec
 
 group :development, :test do
   gem 'pry-byebug' unless ENV['CI']
+
+  # While our gemspec allows sprockets 4, our generator and CI aren't currently working
+  # with it, so we restrict to sprockets 3 for CI here.
+  gem 'sprockets', '~> 3.7'
 end
 
 # BEGIN ENGINE_CART BLOCK

--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,6 @@ gemspec
 
 group :development, :test do
   gem 'pry-byebug' unless ENV['CI']
-
-  # While our gemspec allows sprockets 4, our generator and CI aren't currently working
-  # with it, so we restrict to sprockets 3 for CI here.
-  gem 'sprockets', '~> 3.7'
 end
 
 # BEGIN ENGINE_CART BLOCK

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ If you prefer not to use the generator, or need info on how to set up providers 
 
 Browse-everything depends on bootstrap, it can work with bootstrap 3 or bootstrap 4.
 
+* **NOTE**: The `browse_everything:install` generator will inject a requirement to use sprockets
+3 (instead of 4) into your app's Gemfile. `browse_everything` can work with sprockets 4, if you
+configure your app to use sprockets 4 to serve javascript. But the install generator is not
+currently capable of doing that, so for the moment instead configures your app to use sprockets 3.
+
 ### CSS
 
 **For bootstrap3 support**, your app should include the [bootstrap-sass](https://github.com/twbs/bootstrap-sass) gem in it's Gemfile, and following the install directions for bootstrap-sass, should have `@import 'bootstrap-sprockets'` and `@import 'bootstrap'` in it's application.scss. After those lines, add `@import "browse_everything/browse_everything_bootstrap3";` to your application.scss.

--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '>= 4.2', '< 6.0'
   spec.add_dependency 'ruby-box'
   spec.add_dependency 'signet', '~> 0.8'
-  spec.add_dependency 'sprockets', '~> 3.7'
+  spec.add_dependency 'sprockets', '>= 3.7', "< 5"
   spec.add_dependency 'typhoeus'
 
   spec.add_development_dependency 'bixby', '>= 1.0'

--- a/lib/generators/browse_everything/install_generator.rb
+++ b/lib/generators/browse_everything/install_generator.rb
@@ -10,4 +10,12 @@ class BrowseEverything::InstallGenerator < Rails::Generators::Base
   def inject_config
     generate 'browse_everything:config'
   end
+
+  # While there's no reason browse-everything can't work with a properly configured
+  # sprockets 4 (including configured to deal with Javascript), our install generator
+  # isn't capable of setting this up right now, so instead we'll inject into the app
+  # a sprockets 3 requirement...
+  def sprockets_3_restriction
+    gem 'sprockets', '~> 3.7'
+  end
 end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -8,6 +8,7 @@ else
   gem "bootstrap"
 end
 
-# Can't explain why this is necessary
+# Can't explain why these restrictions are necessary for circle-ci to pass, they
+# should not be, and do not seem required to have tests pass locally.
 gem 'puma', "~> 3.11"
 gem 'sprockets', "~> 3.7"

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -7,3 +7,7 @@ else
   # bootstrap 4
   gem "bootstrap"
 end
+
+# Can't explain why this is necessary
+gem 'puma', "~> 3.11"
+gem 'sprockets', "~> 3.7"


### PR DESCRIPTION
While restricting to sprockets 3 in Gemfile, since our CI does not currently work with sprockets 4. 

One attempt at addressing #310

OK, so this is passing. Interesting. I'm going to try to write up the situation again, as currently. It's pretty confusing, in part because the sprockets 4 rollout in Rails ended up so confusing, being spread over a couple years. This is all pretty confusing. 

* browse_everything up to 1.0.1 did not express a sprockets dependency
* browse_everything in 1.0.2 started requiring sprockets 3.x, not allowing 4.x
* old versions of Rails *install* with sprockets 3 if you just run `run rails something`, you have to change some things in your Gemfile to use sprockets 4. You can do so however. 
* newer versions of Rails (I think starting 6.0.1 or 6.0.2 -- not actually 6.0.0!) will install using sprockets if you just run `rails new something`. 
* sprockets 4 in rails *by default* will not compile Javascript only CSS. But you can modify your config to have sprockets compiling JS even with sprockets 4
* I have an app using rails 6 and sprockets 4 and browse_everything that is working fine. browse_everything doesn't actually require sprockets 3, sprockets 4 is not actually incompatible with it in any way -- once you've adjusted your config to have sprockets compiling JS, to get the browse-everything JS in there. 
* I can not upgrade that app to browse_everything 1.0.2, because 1.0.2 does not allow sprockets 4, it can only be used in an app that is sprockets 3. **This is a problem**
* browse_everything's *installer* won't work with sprockets 4. 
   * this is because the files it expects to be modifying aren't there, and sprockets 4 doesn't by default compile JS at all, which is the only way we have to supply sprockets JS to the app. (Rails seems to expect you to switch to delivering all your JS from engines/gems as npm packages, but this is a lot more work to get right). 
   * you _can_ get b-e to work with sprockets 4 by configuring things properly and configuring sprockets 4 to compile JS, and adding a `javascript_include_tag` to the sprockets JS package in your layout... but the b-e installer doesn't do any of these things. 
   * which also means as it is, CI (circle-ci presently) would fail if b-e allowed sprockets 4
   * which is why b-e 1.0.2 stopped doing so. 
* by sprockets 1.0.2 requiring sprockets 3, it means if you create a rails app with `rails new someapp`, it will start out using sprockets 4... then when you run the b-e installer, it will *downgrade* to sprockets 3. 
   * you might never notice if you do this in a fresh app right away, say as part of a hyrax setup
   * but if you had an existing app already using sprockets 4, downgrading to sprockets 4 might *break things*.  **this is also not okay**. 
   * or depending on what other dependencies you have in the future, trying to install b-e might just fail (if you have something in your dependency tree that insists on sprockets 4). 

So what a mess!

## Ideal solution?

Ideally, browse_everything should work with sprockets 4, including it's automatic installer working with sprockets 4.  Making the installer do that is kind of complicated. Especially if it's going to be trying to reconfigure sprockets 4 to compile Javascript, create necessary config files, add a sprockets-powered `javascript_include_tag`, etc. Complicated, and opening up the attack surface for bugs a lot. 

It perhaps *also* needs to work with sprockets 3, for apps that still have sprockets 3. Which is even more complicated. 

Making things more complicated at least for me is that I find dealing with `engine_cart` very challenging, have never really wrapped my head around that. And I don't understand circle_ci either, haven't used it much and find it difficult. And I personally can't get b-e tests to run locally either. 

@jrgriffiniii made an attempt in #311 , but it's been languishing for nearly 6 months, becuase, well, it's hard. I don't feel capable of solving the problem either at the moment, it's super messy. 

## Can we do a less ideal for-now solution that at least doesn't forbid an app using b-e from using sprockets 4?

### Really stupid solution: don't require a sprockets version in gemspec, do require it in Gemfile

The first version of this PR removes the sprocketes requirement from the gemspec, returning the stuation to what it was in browse_everything 1.0.1. 

Now the installer won't work on any app using sprockets 4. And since latest `rails new` apps use sprockets 4, CI also won't work. 

Then we add the sprockets 3.x dependency to our local `Gemfile`. The Gemfile is used for CI -- so CI passes again. But the Gemfile has no effect on an actual app using the b-e gem at all. 

So the b-e installer still doesn't work on any app that is using sprockets 4, the b-e installation instructions won't work for a lot of people. 

This is probably not good enough. 

### Better, generate a sprockets 3.x requirement into app?

OK what if we enhance this. Take the sprockets requirement out of the gemspec. 

But make the sprockets installer add a `sprockets, "~> 3.7"` requirement to the _local app's Gemfile_. 

This will still have some of the downsides of the current b-e 1.0.2 situation --  if your app started out using sprockets 4, installing b-e will insist on *downgrading* to sprockets 3 (and fail if it can't because of a conflict).  This is not ideal. But it's what is *already* happening. 

The difference is because the restriction is generated into the Gemfile, the local developers have the *option* to edit their own apps files (Gemfiles, sprockets configuration, etc), to upgrade to sprockets 4. 

So may app could keep using sprockets 4 and upgrade to b-e 1.0.2 and subsequent. 

This is really still not ideal, it's a big mess... but seems to be preferable to any other option, unless we can finish #311 maybe, which I personally do not feel confident I can, and it's been sitting there for six months. 

I am going to look into trying to do this. 