### PR TITLE
Remove support for rails 5.1, rely on ActiveStorage id generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,10 +71,6 @@ workflows:
           ruby_version: 2.6.5
           rails_version: 5.2.4
       - build:
-          name: "ruby2-6_rails5-1"
-          ruby_version: 2.6.5
-          rails_version: 5.1.7
-      - build:
           name: "ruby2-5_rails6-0"
           ruby_version: 2.5.7
           rails_version: 6.0.2
@@ -82,7 +78,3 @@ workflows:
           name: "ruby2-5_rails5-2"
           ruby_version: 2.5.7
           rails_version: 5.2.4
-      - build:
-          name: "ruby2-5_rails5-1"
-          ruby_version: 2.5.7
-          rails_version: 5.1.7

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Currently, the following releases of Ruby are supported:
 The supported Rail releases follow those specified by [the security policy of the Rails Community](https://rubyonrails.org/security/).  As is the case with the supported Ruby releases, it is recommended that one upgrades from any Rails release no longer receiving security updates.
 - 6.0.2
 - 5.2.4
-- 5.1.7
 
 _Support for Rails releases earlier than 5.2.z are dropped from 2.0.0 onwards in
 order to maintain core compatibility with [Webpacker]()._

--- a/app/jobs/browse_everything/upload_job.rb
+++ b/app/jobs/browse_everything/upload_job.rb
@@ -57,14 +57,6 @@ module BrowseEverything
         StringIO.new(response.body)
       end
 
-      # This should only be necessary for activestorage 0.1
-      def mint_new_id
-        last = UploadFile.last
-        return 0 unless last
-
-        last.id + 1
-      end
-
       def create_upload_file(bytestream:)
         io = if bytestream.file_uri?
                file_path = bytestream.uri.gsub('file://', '')
@@ -73,7 +65,7 @@ module BrowseEverything
                build_download(bytestream.uri, request_headers)
              end
 
-        upload_file = UploadFile.new(id: mint_new_id, name: bytestream.name)
+        upload_file = UploadFile.new(name: bytestream.name)
         upload_file.bytestream.attach(io: io, filename: bytestream.name, content_type: bytestream.media_type)
         upload_file.save
         upload_file.reload


### PR DESCRIPTION
Resolve duplicate id errors in downstream use