### PR TITLE
Remove sprockets dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,10 @@ jobs:
       - samvera/engine_cart_generate:
           cache_key: v1-internal-test-app-{{ checksum "browse-everything.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/browse_everything/install_generator.rb" }}-{{ checksum "lib/generators/browse_everything/config_generator.rb" }}--<< parameters.rails_version >>-<< parameters.ruby_version >>
 
+      - run:
+         name: Update sprockets to fix version incompatibilities between internal test app and initial bundle install
+         command: bundle update sprockets
+
       - samvera/bundle_for_gem:
           ruby_version: << parameters.ruby_version >>
           bundler_version: << parameters.bundler_version >>

--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '>= 4.2', '< 7.0'
   spec.add_dependency 'ruby-box'
   spec.add_dependency 'signet', '~> 0.8'
-  spec.add_dependency 'sprockets', '~> 3.7'
   spec.add_dependency 'typhoeus'
 
   spec.add_development_dependency 'bixby', '~> 3.0'


### PR DESCRIPTION
Testing removing the sprockets dependency as a first step to understanding and resolving #310 and the PRs: #311 and #345.

In the circleci config it runs bundle install when it has just checked out the code so it pulls in sprockets 4 (or gets it from cache). Then it does engine cart and the rails version might pin it to an earlier version of sprockets there. But after the engine cart generation there's another bundle install which is where the error was happening. So if we precede that with a sprockets upgrade everything seems to work fine. This should now be caching so it shouldn't slow things down, but maybe we want to look at caching more down the line.