### PR TITLE
remove unused google_drive gem dependency

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-s3'
   spec.add_dependency 'dropbox_api', '>= 0.1.10'
   spec.add_dependency 'google-api-client', '~> 0.23'
-  spec.add_dependency 'google_drive', '>= 2.1', "< 4"
   spec.add_dependency 'googleauth', '>= 0.6.6', '< 1.0'
   spec.add_dependency 'rails', '>= 4.2', '< 7.0'
   spec.add_dependency 'ruby-box'


### PR DESCRIPTION
The `google_drive` gem does not seem to actually be used. I can't find it used anywhere, and tests still pass without it.

We do currently use `google-api-client`, that's what's actually used for connecting to google drive storage.  I think it's a mistake that this is still in gemspec. 

See also #363