### PR TITLE
Swap google-api-client for more specific smaller-size gem google-apis-drive_v3

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-s3'
   spec.add_dependency 'dropbox_api', '>= 0.1.10'
   spec.add_dependency 'google-api-client', '~> 0.23'
+  spec.add_dependency 'google-apis-drive_v3'
   spec.add_dependency 'googleauth', '>= 0.6.6', '< 1.0'
   spec.add_dependency 'rails', '>= 4.2', '< 7.0'
   spec.add_dependency 'ruby-box'


### PR DESCRIPTION
google-api-client is deprecated. Closes #363