### PR TITLE
Remove google-api-client dependency

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'aws-sdk-s3'
   spec.add_dependency 'dropbox_api', '>= 0.1.10'
-  spec.add_dependency 'google-api-client', '~> 0.23'
   spec.add_dependency 'google-apis-drive_v3'
   spec.add_dependency 'googleauth', '>= 0.6.6', '< 1.0'
   spec.add_dependency 'rails', '>= 4.2', '< 7.0'


### PR DESCRIPTION
That is now taken care of by google-apis-drive_v3. Having both of them as dependencies is bad, and results in them both trying to supply some of the same classes. This is what #365 was meant to do, but it got corrupted somehow.