### PR TITLE
require 'bootstrap' javascript instead of 'bootstrap-sprockets'

### DIFF
--- a/app/assets/javascripts/browse_everything.js
+++ b/app/assets/javascripts/browse_everything.js
@@ -1,3 +1,3 @@
 //= require jquery.treetable
-//= require bootstrap-sprockets
+//= require bootstrap
 //= require browse_everything/behavior


### PR DESCRIPTION
according to the `bootstrap` rubygem docs:

> While bootstrap-sprockets provides individual Bootstrap components for ease of
> debugging, you may alternatively require the concatenated bootstrap for faster
> compilation

this gem shouldn't force the debugging features on downstream apps.

this is motivated in part by error like this occuring during a bootstrap
upgrade in Hyrax:

> Sprockets::FileNotFound: couldn't find file 'bootstrap-sprockets' with type
> 'application/javascript'