### PR TITLE
update gemspec to allow googleauth gem 1.x

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'aws-sdk-s3'
   spec.add_dependency 'dropbox_api', '>= 0.1.10'
   spec.add_dependency 'google-apis-drive_v3'
-  spec.add_dependency 'googleauth', '>= 0.6.6', '< 1.0'
+  spec.add_dependency 'googleauth', '>= 0.6.6', '< 2.0'
   spec.add_dependency 'rails', '>= 4.2', '< 7.0'
   spec.add_dependency 'ruby-box'
   spec.add_dependency 'signet', '~> 0.8'


### PR DESCRIPTION
googleauth restricted to faraday 1.x until a recent googleauth 1.x release. But apps using browse_everything are currently fixed depending on a version of googleauth that does not allow faraday 2.x, so such apps can't upgrade to faraday 2.x.

This change will allow apps using browse_everything to update to faraday 2.x.

The googleauth change log does not seem to suggest any significant backwards incompat in googleauth 1.x release, so hopefully this change will be fairly impactless otherwise.  https://github.com/googleapis/google-auth-library-ruby/blob/main/CHANGELOG.md
