### PR TITLE
Fix compatibility with dropbox_api 0.1.20+ and force upgrade

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'aws-sdk-s3'
-  spec.add_dependency 'dropbox_api', '>= 0.1.10'
+  spec.add_dependency 'dropbox_api', '>= 0.1.20'
   spec.add_dependency 'google-apis-drive_v3'
   spec.add_dependency 'googleauth', '>= 0.6.6', '< 1.0'
   spec.add_dependency 'rails', '>= 4.2', '< 7.0'

--- a/lib/browse_everything/driver/dropbox.rb
+++ b/lib/browse_everything/driver/dropbox.rb
@@ -124,11 +124,11 @@ module BrowseEverything
       end
 
       def auth_link(url_options)
-        authenticator.authorize_url redirect_uri: redirect_uri(url_options)
+        authenticator.auth_code.authorize_url redirect_uri: redirect_uri(url_options)
       end
 
       def connect(params, _data, url_options)
-        auth_bearer = authenticator.get_token params[:code], redirect_uri: redirect_uri(url_options)
+        auth_bearer = authenticator.auth_code.get_token params[:code], redirect_uri: redirect_uri(url_options)
         self.token = auth_bearer.token
       end
 


### PR DESCRIPTION
dropbox_api 0.1.20 changed the internals of DropboxApi::Authenticator such that calls to get_token and authorize_url
are no longer forwarded to an OAuth2::Strategy::AuthCode instance.  Fixing compatibility required calling these methods
on Authenticator#auth_code.

See https://github.com/Jesus/dropbox_api/pull/88