### PR TITLE
update bixby to latest release

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'signet', '~> 0.8'
   spec.add_dependency 'typhoeus'
 
-  spec.add_development_dependency 'bixby', '~> 3.0'
+  spec.add_development_dependency 'bixby', '~> 5.0'
   spec.add_development_dependency 'bundler', '>= 1.3'
   spec.add_development_dependency 'capybara'
   spec.add_development_dependency 'coveralls'

--- a/lib/browse_everything/driver/base.rb
+++ b/lib/browse_everything/driver/base.rb
@@ -32,6 +32,7 @@ module BrowseEverything
         # @param subclass [Class] the class inheriting from BrowseEverything::Driver::Base
         def inherited(subclass)
           subclass.sorter = sorter
+          super
         end
       end
 


### PR DESCRIPTION
bixby includes rubocop version dependencies. I was having trouble even getting tests to run locally without this, and it's a pre-requisite for work to add support for more ruby/rails versions, I think.

Fixed one issue with calling `super` in `inherited` that new version of bixby/rubocop caught and required fixing to build!