### PR TITLE
Add CircleCI build for ruby 3.0 on Rails 6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,10 @@ workflows:
   ci:
     jobs:
       - build:
+          name: "ruby3-0_rails6-0"
+          ruby_version: 3.0.4
+          rails_version: 6.0.4.7
+      - build:
           name: "ruby2-7_rails6-0"
           ruby_version: 2.7.5
           rails_version: 6.0.4.7

--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ what this means can be found
 
 ## Supported Ruby Releases
 Currently, the following releases of Ruby are tested:
-- 2.7.3
-- 2.6.6
-- 2.5.8
-- 2.4.10
+- 3.0
+- 2.7
+- 2.6
+- 2.5
 
 ## Supported Rails Releases
 The supported Rail releases follow those specified by [the security policy of the Rails Community](https://rubyonrails.org/security/).  As is the case with the supported Ruby releases, it is recommended that one upgrades from any Rails release no longer receiving security updates.
-- 6.0.3
-- 5.2.3
-- 5.1.7
+- 6.0
+- 5.2
+- 5.1
 
 ## Installation
 


### PR DESCRIPTION
Rails 6.0 was already tested with earlier ruby versions. Ruby 3.0.x is the latest ruby supported by Rails 6.0 (it does not support Rails 6.1. Limited docs on this but see https://buildkite.com/rails/rails/builds/87101)