### PR TITLE
jrochkind experimental playground: update samvera/circleci-orb to 1.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 version: 2.1
 orbs:
-  samvera: samvera/circleci-orb@0
+  samvera: samvera/circleci-orb@1.0
 
 jobs:
   build:
@@ -31,10 +31,9 @@ jobs:
             fi
             [[ -z "$(git branch --all --list master */master)" ]]
 
-      - samvera/bundle_for_gem:
+      - samvera/bundle:
           bundler_version: << parameters.bundler_version >>
           ruby_version: << parameters.ruby_version >>
-          project: 'browse-everything'
 
       - samvera/engine_cart_generate:
           cache_key: v1-internal-test-app-{{ checksum "browse-everything.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/browse_everything/install_generator.rb" }}-{{ checksum "lib/generators/browse_everything/config_generator.rb" }}--<< parameters.rails_version >>-<< parameters.ruby_version >>
@@ -85,10 +84,6 @@ workflows:
           name: "ruby2-6_rails5-1"
           ruby_version: 2.6.9
           rails_version: 5.1.7
-      - build:
-          name: "ruby2-5_rails5-1"
-          ruby_version: 2.5.8
-          rails_version: 5.1.7
 
   nightly:
     triggers:
@@ -107,10 +102,6 @@ workflows:
           name: "ruby2-6_rails6-0"
           ruby_version: 2.6.9
           rails_version: 6.0.4.7
-      - build:
-          name: "ruby2-5_rails6-0"
-          ruby_version: 2.5.8
-          rails_version: 6.0.4.7
 
       - build:
           name: "ruby2-7_rails5-2"
@@ -120,10 +111,6 @@ workflows:
           name: "ruby2-6_rails5-2"
           ruby_version: 2.6.9
           rails_version: 5.2.7
-      - build:
-          name: "ruby2-5_rails5-2"
-          ruby_version: 2.5.8
-          rails_version: 5.2.7
 
       - build:
           name: "ruby2-7_rails5-1"
@@ -132,9 +119,5 @@ workflows:
       - build:
           name: "ruby2-6_rails5-1"
           ruby_version: 2.6.9
-          rails_version: 5.1.7
-      - build:
-          name: "ruby2-5_rails5-1"
-          ruby_version: 2.5.8
           rails_version: 5.1.7
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,10 @@ workflows:
   ci:
     jobs:
       - build:
+          name: "ruby3-0_rails6-0"
+          ruby_version: 3.0.3
+          rails_version: 6.0.4.7
+      - build:
           name: "ruby2-7_rails6-0"
           ruby_version: 2.7.5
           rails_version: 6.0.4.7
@@ -94,6 +98,10 @@ workflows:
               only:
                 - main
     jobs:
+      - build:
+          name: "ruby3-0_rails6-0"
+          ruby_version: 3.0.3
+          rails_version: 6.0.4.7
       - build:
           name: "ruby2-7_rails6-0"
           ruby_version: 2.7.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,11 @@ workflows:
   ci:
     jobs:
       - build:
+          name: "ruby3-0_rails6-1"
+          ruby_version: 3.0.3
+          rails_version: 6.1.6
+
+      - build:
           name: "ruby3-0_rails6-0"
           ruby_version: 3.0.3
           rails_version: 6.0.4.7
@@ -98,6 +103,11 @@ workflows:
               only:
                 - main
     jobs:
+      - build:
+          name: "ruby3-0_rails6-1"
+          ruby_version: 3.0.3
+          rails_version: 6.1.6
+
       - build:
           name: "ruby3-0_rails6-0"
           ruby_version: 3.0.3

--- a/README.md
+++ b/README.md
@@ -39,10 +39,8 @@ what this means can be found
 
 ## Supported Ruby Releases
 Currently, the following releases of Ruby are tested:
-- 2.7.3
-- 2.6.6
-- 2.5.8
-- 2.4.10
+- 2.7
+- 2.6
 
 ## Supported Rails Releases
 The supported Rail releases follow those specified by [the security policy of the Rails Community](https://rubyonrails.org/security/).  As is the case with the supported Ruby releases, it is recommended that one upgrades from any Rails release no longer receiving security updates.

--- a/README.md
+++ b/README.md
@@ -39,14 +39,16 @@ what this means can be found
 
 ## Supported Ruby Releases
 Currently, the following releases of Ruby are tested:
+- 3.0
 - 2.7
 - 2.6
 
 ## Supported Rails Releases
 The supported Rail releases follow those specified by [the security policy of the Rails Community](https://rubyonrails.org/security/).  As is the case with the supported Ruby releases, it is recommended that one upgrades from any Rails release no longer receiving security updates.
-- 6.0.3
-- 5.2.3
-- 5.1.7
+- 6.1
+- 6.0
+- 5.2
+- 5.1
 
 ## Installation
 

--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dropbox_api', '>= 0.1.20'
   spec.add_dependency 'google-apis-drive_v3'
   spec.add_dependency 'googleauth', '>= 0.6.6', '< 2.0'
-  spec.add_dependency 'rails', '>= 4.2', '< 7.0'
+  spec.add_dependency 'rails', '>= 4.2', '< 7.1'
   spec.add_dependency 'ruby-box'
   spec.add_dependency 'signet', '~> 0.8'
   spec.add_dependency 'typhoeus'


### PR DESCRIPTION
* Remove ruby 2.5 support, the new orb switches to `cimg` circleci ruby images that do not support ruby 2.5
* Switch from deprecated samvera orb `bundle_for_gem` command to preferred `bundle` command.
