### PR TITLE
CI Build with rails 6.0 and ruby 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,10 @@ workflows:
   ci:
     jobs:
       - build:
+          name: "ruby3-0_rails6-0"
+          ruby_version: 3.0.3
+          rails_version: 6.0.4.7
+      - build:
           name: "ruby2-7_rails6-0"
           ruby_version: 2.7.5
           rails_version: 6.0.4.7
@@ -89,6 +93,10 @@ workflows:
               only:
                 - main
     jobs:
+      - build:
+          name: "ruby3-0_rails6-0"
+          ruby_version: 3.0.3
+          rails_version: 6.0.4.7
       - build:
           name: "ruby2-7_rails6-0"
           ruby_version: 2.7.5


### PR DESCRIPTION
We think rails 6.0.3+ does support ruby 3.0 but not ruby 3.1. https://buildkite.com/rails/rails/builds/87101

Rails earlier than 6.0 does not support ruby 3.0, should not be tested with it.

Closes #373 and replaces #385