### PR TITLE
Rails 6.1 ruby 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           ruby_version: << parameters.ruby_version >>
 
       - samvera/engine_cart_generate:
-          cache_key: v1-internal-test-app-{{ checksum "browse-everything.gemspec" }}-{{ checksum "Gemfile" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/browse_everything/install_generator.rb" }}-{{ checksum "lib/generators/browse_everything/config_generator.rb" }}--<< parameters.rails_version >>-<< parameters.ruby_version >>
+          cache_key: v1-internal-test-app-{{ checksum "browse-everything.gemspec" }}-{{ checksum "Gemfile" }}--{{ checksum "spec/test_app_templates/Gemfile.extra" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/browse_everything/install_generator.rb" }}-{{ checksum "lib/generators/browse_everything/config_generator.rb" }}--<< parameters.rails_version >>-<< parameters.ruby_version >>
 
       - run:
          name: Update sprockets to fix version incompatibilities between internal test app and initial bundle install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,10 @@ workflows:
   ci:
     jobs:
       - build:
+          name: "ruby3-1_rails6-1"
+          ruby_version: 3.1.2
+          rails_version: 6.1.6
+      - build:
           name: "ruby3-0_rails6-1"
           ruby_version: 3.0.3
           rails_version: 6.1.6
@@ -98,6 +102,10 @@ workflows:
               only:
                 - main
     jobs:
+      - build:
+          name: "ruby3-1_rails6-1"
+          ruby_version: 3.1.2
+          rails_version: 6.1.6
       - build:
           name: "ruby3-0_rails6-1"
           ruby_version: 3.0.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,8 @@ jobs:
           cache_key: v1-internal-test-app-{{ checksum "browse-everything.gemspec" }}-{{ checksum "Gemfile" }}--{{ checksum "spec/test_app_templates/Gemfile.extra" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/browse_everything/install_generator.rb" }}-{{ checksum "lib/generators/browse_everything/config_generator.rb" }}--<< parameters.rails_version >>-<< parameters.ruby_version >>
 
       - run:
-         name: Update sprockets to fix version incompatibilities between internal test app and initial bundle install
-         command: bundle update sprockets
+         name: Update bundle to fix version incompatibilities between internal test app and initial bundle install
+         command: bundle update
 
       - samvera/rubocop
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ what this means can be found
 
 ## Supported Ruby Releases
 Currently, the following releases of Ruby are tested:
+- 3.1
 - 3.0
 - 2.7
 - 2.6

--- a/lib/browse_everything.rb
+++ b/lib/browse_everything.rb
@@ -55,7 +55,7 @@ module BrowseEverything
         begin
           config_file_content = File.read(value)
           config_file_template = ERB.new(config_file_content)
-          config_values = YAML.safe_load(config_file_template.result, [Symbol])
+          config_values = YAML.safe_load(config_file_template.result, permitted_classes: [Symbol])
           @config = ActiveSupport::HashWithIndifferentAccess.new config_values
           @config.deep_symbolize_keys
         rescue Errno::ENOENT

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,0 +1,9 @@
+# Only necessary until mail 2.8.0 is released, allow us to build with engine_cart
+# under Rails 6.1 and ruby 3.1, by opting into using pre-release version of mail
+# 2.8.0.rc1
+#
+# https://github.com/mikel/mail/pull/1472
+
+if ENV['RAILS_VERSION'] && ENV['RAILS_VERSION'] =~ /^6\.1\./ && RUBY_VERSION =~ /^3\.1\./
+  gem "mail", ">= 2.8.0.rc1"
+end


### PR DESCRIPTION
* Requires some Gemfile.extra business to get engine_cart to succesfully create a rails 6.1/ruby 3.1 project prior to `mail` gem 2.8.0 being released. https://bibwild.wordpress.com/2022/06/13/using-engine_cart-with-rails-6-1-and-ruby-3-1/

* Then we run into an actual 3.1 failure, with removal of deprecated method args for `YAML.safe_load`, need to use new non-deprecated form of arg.  New non-deprecated form is available as of ruby 2.6 -- and we already dropped ruby 2.5 from support/CI build matrix in #395 , so we're good without a conditional! 
   * Closes #389