### PR TITLE
Support for Rails 7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,11 @@ workflows:
   ci:
     jobs:
       - build:
+          name: "ruby3-1_rails7-0"
+          ruby_version: 3.1.2
+          rails_version: 7.0.3
+
+      - build:
           name: "ruby3-1_rails6-1"
           ruby_version: 3.1.2
           rails_version: 6.1.6
@@ -102,6 +107,11 @@ workflows:
               only:
                 - main
     jobs:
+      - build:
+          name: "ruby3-1_rails7-0"
+          ruby_version: 3.1.2
+          rails_version: 7.0.3
+
       - build:
           name: "ruby3-1_rails6-1"
           ruby_version: 3.1.2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,3 +79,7 @@ Style/NumericLiterals:
 Style/RedundantBegin:
   Exclude:
     - 'lib/browse_everything/browser.rb'
+
+Style/IfUnlessModifier:
+  Exclude:
+    - 'Gemfile'

--- a/Gemfile
+++ b/Gemfile
@@ -44,3 +44,11 @@ else
   end
 end
 # END ENGINE_CART BLOCK
+
+# rspec-rails 6.0 is required for Rails 7 support, it's currently only in pre-release,
+# opt into it here. This should not be required when rspec-rails 6.0.0 final is released.
+# Note rspec-rails 6.0.0 does not support rails before 6.1, so different versions of
+# rspec-rails will be needed for different jobs, but that should happen automatically.
+if ENV['RAILS_VERSION'] && ENV['RAILS_VERSION'] =~ /^7\.0\./
+  gem "rspec-rails", ">= 6.0.0.rc1"
+end

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Currently, the following releases of Ruby are tested:
 
 ## Supported Rails Releases
 The supported Rail releases follow those specified by [the security policy of the Rails Community](https://rubyonrails.org/security/).  As is the case with the supported Ruby releases, it is recommended that one upgrades from any Rails release no longer receiving security updates.
+- 7.0
 - 6.1
 - 6.0
 - 5.2

--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dropbox_api', '>= 0.1.20'
   spec.add_dependency 'google-apis-drive_v3'
   spec.add_dependency 'googleauth', '>= 0.6.6', '< 2.0'
-  spec.add_dependency 'rails', '>= 4.2', '< 7.0'
+  spec.add_dependency 'rails', '>= 4.2', '< 7.1'
   spec.add_dependency 'ruby-box'
   spec.add_dependency 'signet', '~> 0.8'
   spec.add_dependency 'typhoeus'

--- a/lib/browse_everything/engine.rb
+++ b/lib/browse_everything/engine.rb
@@ -2,8 +2,15 @@
 
 module BrowseEverything
   class Engine < ::Rails::Engine
-    config.assets.paths << config.root.join('vendor', 'assets', 'javascripts')
-    config.assets.paths << config.root.join('vendor', 'assets', 'stylesheets')
-    config.assets.precompile += %w[browse_everything.js browse_everything.css]
+    # As of Rails 7, sprockets is optional in Rails. If you don't have sprockets-rails
+    # installed, you don't have a config.assets.  Without sprockets, you may
+    # or may not be able to figure out how to get browse-everything JS and CSS to load,
+    # but we should at least let you load the engine and try, so we don't try
+    # to configure sprockets unless it is installed...
+    if config.respond_to?(:assets)
+      config.assets.paths << config.root.join('vendor', 'assets', 'javascripts')
+      config.assets.paths << config.root.join('vendor', 'assets', 'stylesheets')
+      config.assets.precompile += %w[browse_everything.js browse_everything.css]
+    end
   end
 end


### PR DESCRIPTION
Or at least build passes -- actually getting your CSS and JS loaded in a real Rails 7 app would require some not totally documented steps, but that's really an existing problem that applies to Rails 6.1  (and possibly earlier) too, unfortunately, a separate problem. 

Minimal actual code changes were required to get build to pass on Rails 7. 

- allow Rails 7 in gemspec
- don't try to configure sprockets if sprockets not included in app
  - sprockets-rails is now optional for rails 7. Without it... not totally sure how you're going to get b-e CSS and JS to load, but let's at least let you try by not crashing. (The test setup is at least trying to include JS with Webpacker somehow...)
- Opt into rspec-rails 6.0.0.rc1 for Rails 7 compat
- Test circleci under rails 7, ruby 3.1
