### PR TITLE
Get feature tests working again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@
 version: 2.1
 orbs:
   samvera: samvera/circleci-orb@1.0
+  browser-tools: circleci/browser-tools@1.1
 
 jobs:
   build:
@@ -19,6 +20,8 @@ jobs:
     environment:
       RAILS_VERSION: << parameters.rails_version >>
     steps:
+      - browser-tools/install-browser-tools
+
       - samvera/cached_checkout
 
       - run:

--- a/spec/features/select_files_spec.rb
+++ b/spec/features/select_files_spec.rb
@@ -7,7 +7,7 @@ describe 'Choosing files', type: :feature, js: true do
 
   shared_examples 'browseable files' do
     # This is a work-around until the support for Webpacker is resolved
-    xit 'selects files from the filesystem' do
+    it 'selects files from the filesystem' do
       click_button('Browse')
       wait_for_ajax
 

--- a/spec/features/test_compiling_stylesheets_spec.rb
+++ b/spec/features/test_compiling_stylesheets_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe 'Compiling the stylesheets', type: :feature, js: true do
-  xit 'does not raise errors' do
+  it 'does not raise errors' do
     visit '/'
     expect(page).not_to have_content 'Sass::SyntaxError'
   end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -7,3 +7,11 @@
 if ENV['RAILS_VERSION'] && ENV['RAILS_VERSION'] =~ /^6\.1\./ && RUBY_VERSION =~ /^3\.1\./
   gem "mail", ">= 2.8.0.rc1"
 end
+
+# We need bootstrap gem dependencies to build our CSS under sprockets
+
+if ENV['TEST_BOOTSTRAP'] == "3"
+  gem "bootstrap-sprockets"
+else # bootstrap 4. We don't yet support bootstrap 5.
+  gem "bootstrap", "~> 4.0"
+end


### PR DESCRIPTION
To compile bootstrap CSS from bootstrap gem(s), we need the bootstrap gem(s) in project! Correct gem for bootstrap 3 or 4. (We do not currently support 5).
