### PR TITLE
Circleci, only specify ruby to minor version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,10 @@ jobs:
       - samvera/bundle:
           bundler_version: << parameters.bundler_version >>
           ruby_version: << parameters.ruby_version >>
+          # re-including ruby and rails versions in cache_version I believe
+          # works around what I think is a bug in samvera/bundle caching where
+          # it's re-using caches that are no good.
+          cache_version: 1-<< parameters.ruby_version >>-<< parameters.rails_version >>
 
       - samvera/engine_cart_generate:
           cache_key: v1-internal-test-app-{{ checksum "browse-everything.gemspec" }}-{{ checksum "Gemfile" }}--{{ checksum "spec/test_app_templates/Gemfile.extra" }}-{{ checksum "spec/test_app_templates/lib/generators/test_app_generator.rb" }}-{{ checksum "lib/generators/browse_everything/install_generator.rb" }}-{{ checksum "lib/generators/browse_everything/config_generator.rb" }}--<< parameters.rails_version >>-<< parameters.ruby_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,47 +51,47 @@ workflows:
     jobs:
       - build:
           name: "ruby3-1_rails7-0"
-          ruby_version: 3.1.2
+          ruby_version: "3.1"
           rails_version: 7.0.3
 
       - build:
           name: "ruby3-1_rails6-1"
-          ruby_version: 3.1.2
+          ruby_version: "3.1"
           rails_version: 6.1.6
       - build:
           name: "ruby3-0_rails6-1"
-          ruby_version: 3.0.3
+          ruby_version: "3.0"
           rails_version: 6.1.6
 
       - build:
           name: "ruby3-0_rails6-0"
-          ruby_version: 3.0.3
+          ruby_version: "3.0"
           rails_version: 6.0.4.7
       - build:
           name: "ruby2-7_rails6-0"
-          ruby_version: 2.7.5
+          ruby_version: "2.7"
           rails_version: 6.0.4.7
       - build:
           name: "ruby2-6_rails6-0"
-          ruby_version: 2.6.9
+          ruby_version: "2.6"
           rails_version: 6.0.4.7
 
       - build:
           name: "ruby2-7_rails5-2"
-          ruby_version: 2.7.5
+          ruby_version: "2.7"
           rails_version: 5.2.7
       - build:
           name: "ruby2-6_rails5-2"
-          ruby_version: 2.6.9
+          ruby_version: "2.6"
           rails_version: 5.2.7
 
       - build:
           name: "ruby2-7_rails5-1"
-          ruby_version: 2.7.5
+          ruby_version: "2.7"
           rails_version: 5.1.7
       - build:
           name: "ruby2-6_rails5-1"
-          ruby_version: 2.6.9
+          ruby_version: "2.6"
           rails_version: 5.1.7
 
   nightly:
@@ -105,46 +105,46 @@ workflows:
     jobs:
       - build:
           name: "ruby3-1_rails7-0"
-          ruby_version: 3.1.2
+          ruby_version: "3.1"
           rails_version: 7.0.3
 
       - build:
           name: "ruby3-1_rails6-1"
-          ruby_version: 3.1.2
+          ruby_version: "3.1"
           rails_version: 6.1.6
       - build:
           name: "ruby3-0_rails6-1"
-          ruby_version: 3.0.3
+          ruby_version: "3.0"
           rails_version: 6.1.6
 
       - build:
           name: "ruby3-0_rails6-0"
-          ruby_version: 3.0.3
+          ruby_version: "3.0"
           rails_version: 6.0.4.7
       - build:
           name: "ruby2-7_rails6-0"
-          ruby_version: 2.7.5
+          ruby_version: "2.7"
           rails_version: 6.0.4.7
       - build:
           name: "ruby2-6_rails6-0"
-          ruby_version: 2.6.9
+          ruby_version: "2.6"
           rails_version: 6.0.4.7
 
       - build:
           name: "ruby2-7_rails5-2"
-          ruby_version: 2.7.5
+          ruby_version: "2.7"
           rails_version: 5.2.7
       - build:
           name: "ruby2-6_rails5-2"
-          ruby_version: 2.6.9
+          ruby_version: "2.6"
           rails_version: 5.2.7
 
       - build:
           name: "ruby2-7_rails5-1"
-          ruby_version: 2.7.5
+          ruby_version: "2.7"
           rails_version: 5.1.7
       - build:
           name: "ruby2-6_rails5-1"
-          ruby_version: 2.6.9
+          ruby_version: "2.6"
           rails_version: 5.1.7
 


### PR DESCRIPTION
Stop specifying patch version, so we will use the latest patch version. Circleci says:

> <ruby-version> - The version of Ruby to use. This can be a full SemVer point release (such as 2.6.5) or just the minor release (such as 2.6). If you use the minor release tag, it will automatically point to future patch updates as they are released. For example, the tag 2.6 points to Ruby v2.6.5 now, but when the next release comes out, it will point to Ruby v2.6.6

--https://circleci.com/developer/images/image/cimg/ruby#how-this-image-works

Note with only two numerical components, need to enclose it in quotes eg `"2.7"` so YAML will parse it as a string as circleci/orbs want, instead of a decimal number.