### PR TITLE
Tweak some javascript problems

### DIFF
--- a/app/assets/javascripts/browse_everything/behavior.js
+++ b/app/assets/javascripts/browse_everything/behavior.js
@@ -447,9 +447,15 @@ var auto_toggle = function auto_toggle() {
 if (typeof Turbolinks !== 'undefined' && Turbolinks !== null && Turbolinks.supported) {
   // Use turbolinks:load for Turbolinks 5, otherwise use the old way
   if (Turbolinks.BrowserAdapter) {
-    $(document).on('turbolinks:load', auto_toggle);
+    $(document).on('turbolinks:load', function() {
+      // make sure turbolinks:load AND jquery onReady have BOTH happened,
+      // they could come in any order.
+      $(auto_toggle);
+    });
   } else {
-    $(document).on('page:change', auto_toggle);
+    $(document).on('page:change', function() {
+      $(auto_toggle);
+    });
   }
 } else {
   $(auto_toggle);

--- a/app/assets/javascripts/browse_everything/behavior.js
+++ b/app/assets/javascripts/browse_everything/behavior.js
@@ -452,5 +452,5 @@ if (typeof Turbolinks !== 'undefined' && Turbolinks !== null && Turbolinks.suppo
     $(document).on('page:change', auto_toggle);
   }
 } else {
-  $(document).ready(auto_toggle);
+  $(auto_toggle);
 }

--- a/spec/support/app/views/file_handler/index.html.erb
+++ b/spec/support/app/views/file_handler/index.html.erb
@@ -1,6 +1,10 @@
 <div class="panel panel-default">
   <div class="panel-body">
     <a href="main" class="btn btn-large btn-primary" role="button">Enter Test App (Turbolinks)</a>
-    <a href="main" class="btn btn-large btn-primary" role="button" data-no-turbolink>Enter Test App (No Turbolinks)</a>
+
+    <%# this doesn't REALLY test no Turbolinks, as there will still be a `window.Turbolinks` object,
+        and a `turbolinks:load` event. It just tests as if the page we are navigating to were the FIRST
+        page loaded under turbolinks %>
+    <a href="main" class="btn btn-large btn-primary" role="button" data-turbolinks="false" data-no-turbolink>Enter Test App (No Turbolinks)</a>
   </div>
 </div>

--- a/spec/support/app/views/file_handler/main.html.erb
+++ b/spec/support/app/views/file_handler/main.html.erb
@@ -14,9 +14,12 @@
 
   <script>
     $(document).on('turbolinks:load', function() {
-      $('#browse-btn').browseEverything()
-        .done(function(data) { $('#status').html(data.length.toString() + " items selected") })
-        .cancel(function()   { window.alert('Canceled!') });
+      // Have to make sure onReady is ALSO passed, in case it's first load.
+      $(function() {
+        $('#browse-btn').browseEverything()
+          .done(function(data) { $('#status').html(data.length.toString() + " items selected") })
+          .cancel(function()   { window.alert('Canceled!') });
+      });
     });
   </script>
 </div>

--- a/spec/test_app_templates/lib/generators/test_app_generator.rb
+++ b/spec/test_app_templates/lib/generators/test_app_generator.rb
@@ -65,6 +65,7 @@ class TestAppGenerator < Rails::Generators::Base
       # Adding the JavaScript module dependencies
       insert_into_file 'app/javascript/packs/browse-everything.js', before: "'use strict';" do
         %(
+          import Rails from '@rails/ujs'
           require("bootstrap")
           require("./treetable")
         )


### PR DESCRIPTION
While CI isn't currently running JS feature tests (working on it in #400), I _am_ able to run them locally (and have them be green -- both before and after this PR).  These fixes came from such, as well as from manually running the engine_cart `.internal_test_app` and manipulating it in manual tests. 

## "(No Turbolinks)" feature test path wasn't, and wasn't any different -- plus failed when fixed

Feature tests [tried to test a "No Turbolinks" test path](https://github.com/samvera/browse-everything/blob/35b4e3cd1a6fd10f79bcfd3d4cebc9fe4d3ebe89/spec/features/select_files_spec.rb#L34), by [clicking on a link with "data-no-turbolink" attribute](https://github.com/samvera/browse-everything/blob/35b4e3cd1a6fd10f79bcfd3d4cebc9fe4d3ebe89/spec/support/app/views/file_handler/index.html.erb#L4)

Two problems with this:

1. That attribute has no effect on recent versions of Turbolinks that were being used in tests, it needs to be `data-turbolinks="false"` instead. So this test path was not doing anything different at all from the "(Turbolinks)" test path. 
2. Technically even once working, it's nto testing "no turbolinks", it's testing:  Turbolinks is loaded, and page with b-e is the FIRST page in the turbolinks session, so loaded with a full load. 

I fixed (1).  While it's not "no turbolinks" it turns out that IS a test path we want to test, because once it was testing the "first load with turbolinks" condition, a previously green test went red!

I fixed that by ensuring some JS code that was waiting only on `turbolinks:load` would wait **BOTH** on turbolinks:load and **ready**.   In "first page load" scenario, `turbolinks:load` could happen _before_ `ready`, and the triggered code was firing before structures it needed were set up. 

## CSRF failure in test app setup

The current [test app setup](https://github.com/samvera/browse-everything/blob/35b4e3cd1a6fd10f79bcfd3d4cebc9fe4d3ebe89/spec/test_app_templates/lib/generators/test_app_generator.rb) does some frankenstein things to set up a test app that can deliver b-e JS with webpack:  It copies some JS source into local app, and then even _modifies_ those files a bit to add some require/imports to refer to dependencies for webpack. 

When i ran the `.internal_test_app` manually, it was failing to include a proper CSRF token when POST'ing back to app, and thus failing the CSRF check and not fully succeeding in browse-everything file selection.

* ==>  This was _not_ failing in test environment for reasons that are still a mystery to me. The feature test was passing fine, testing for succesful file selection -- in a way that when i did it manually, definitely failed!  I can't figure this out, but fixed it anyway. 

The reason was because it was trying to find a CSRF token to include with request using a `Rails` JS object, only if the `Rails` JS object was present -- but in webpack environment, to be able to refer to `Rails` you have to import it. 

So I added that import to the test_app_generator. Now, manually running the engine-cart test app, and manually testing it -- b-e file selection works to completion, with no Rails HTTP status 422 CSRF failure. 