### PR TITLE
Run CI with Ruby 3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,10 @@ workflows:
   ci:
     jobs:
       - build:
+          name: "ruby3-2_rails7-0"
+          ruby_version: 3.2.0
+          rails_version: 7.0.3
+      - build:
           name: "ruby3-1_rails7-0"
           ruby_version: 3.1.2
           rails_version: 7.0.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
         type: string
       bundler_version:
         type: string
-        default: 2.1.4
+        default: 2.4.3
     executor:
       name: 'samvera/ruby'
       ruby_version: << parameters.ruby_version >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,11 +48,11 @@ workflows:
       - build:
           name: "ruby3-2_rails7-0"
           ruby_version: 3.2.0
-          rails_version: 7.0.3
+          rails_version: 7.0.4
       - build:
           name: "ruby3-1_rails7-0"
           ruby_version: 3.1.2
-          rails_version: 7.0.3
+          rails_version: 7.0.4
 
       - build:
           name: "ruby3-1_rails6-1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,9 +104,13 @@ workflows:
                 - main
     jobs:
       - build:
+          name: "ruby3-2_rails7-0"
+          ruby_version: 3.2.0
+          rails_version: 7.0.4
+      - build:
           name: "ruby3-1_rails7-0"
           ruby_version: 3.1.2
-          rails_version: 7.0.3
+          rails_version: 7.0.4
 
       - build:
           name: "ruby3-1_rails6-1"


### PR DESCRIPTION
Locally tests passed under Rails 7.0 and Ruby 3.2 with no changes to code. 
