### PR TITLE
make google oauth tests pass again

### DIFF
--- a/spec/lib/browse_everything/auth/google/credentials_spec.rb
+++ b/spec/lib/browse_everything/auth/google/credentials_spec.rb
@@ -32,7 +32,7 @@ describe BrowseEverything::Auth::Google::Credentials do
 
     it 'requests a new token from the OAuth provider' do
       expect(credentials.fetch_access_token).to be_a Hash
-      expect(credentials.fetch_access_token).to eq({})
+      expect(credentials.fetch_access_token).to eq({ "granted_scopes" => nil })
     end
 
     after do


### PR DESCRIPTION
Something has changed in dependencies such that test results are different, I don't believe it effects functionality, but also am not sure google oauth actually works at all, can't say personally.
