### PR TITLE
Fix CI setup

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -48,7 +48,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'sass-rails'
   spec.add_development_dependency 'selenium-webdriver'
-  spec.add_development_dependency 'sqlite3'
+  # Rails <= 7.1 can't use sqlite3 gem 2.x yet
+  spec.add_development_dependency 'sqlite3', "~> 1.4"
   spec.add_development_dependency 'turbolinks'
   spec.add_development_dependency 'webdrivers'
   spec.add_development_dependency 'webmock'

--- a/lib/browse_everything/auth/google/request_parameters.rb
+++ b/lib/browse_everything/auth/google/request_parameters.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
+require 'ostruct'
+
 # Manages request parameters for the request to the Google Drive API
 module BrowseEverything
   module Auth
     module Google
-      class RequestParameters < OpenStruct
+      class RequestParameters < ::OpenStruct
         # Overrides the constructor for an OpenStruct instance
         # Provides default parameters
         def initialize(params = {})

--- a/lib/browse_everything/driver/base.rb
+++ b/lib/browse_everything/driver/base.rb
@@ -69,7 +69,7 @@ module BrowseEverything
       # Generate the name for the driver
       # @return [String]
       def name
-        @name ||= (@config[:name] || self.class.name.split(/::/).last.titleize)
+        @name ||= @config[:name] || self.class.name.split(/::/).last.titleize
       end
 
       # Abstract method


### PR DESCRIPTION
Several accumulated test setup things were preventing green CI.  In some cases I don't really understand how CI used to pass but stopped with no code changes, but these changes all make sense. 

## Fix rubocop violation on parens around logical expression
 
Don't know exactly how this got in main branch, but currently failing build due to:

```
lib/browse_everything/driver/base.rb:72:19: C: [Correctable] Style/RedundantParentheses: Don't use parentheses around a logical expression.
        @name ||= (@config[:name] || self.class.name.split(/::/).last.titleize)
```


## OpenStruct reference

Again can't explain why this passed CI at some previous point but stopped, but was getting errors with:

```
     NameError:
       uninitialized constant BrowseEverything::Auth::Google::OpenStruct
     # ./lib/browse_everything/auth/google/request_parameters.rb:7:in `<module:Google>'
```

Fixed with `require 'ostruct'` and changing reference to explicit top-level `::OpenStruct`. 


## Sqlite3 version

sqlite3 ruby gem 2.x came out a few months ago. But Rails versions <= 7.1 still need to use 1.x I think?  Error like:

```
       # Gem::LoadError:
       #   can't activate sqlite3 (~> 1.4), already activated sqlite3-2.0.2. Make sure all dependencies are added to Gemfile.
```

Changed development dependency in gemspec to:

    spec.add_development_dependency 'sqlite3', "~> 1.4"

