### PR TITLE
Updating the tool versions and removing Ruby releases prior to 3.1 and Rails releases 6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
         type: string
       bundler_version:
         type: string
-        default: 2.4.3
+        default: 2.5.21
     executor:
       name: 'samvera/ruby'
       ruby_version: << parameters.ruby_version >>
@@ -47,50 +47,24 @@ workflows:
     jobs:
       - build:
           name: "ruby3-3_rails7-2"
-          ruby_version: 3.3.3
-          rails_version: "7.2.0"
-
-
+          ruby_version: 3.3.5
+          rails_version: 7.2.1
       - build:
           name: "ruby3-2_rails7-1"
-          ruby_version: 3.2.1
-          rails_version: 7.1.1
+          ruby_version: 3.2.5
+          rails_version: 7.1.4
       - build:
           name: "ruby3-2_rails7-0"
-          ruby_version: 3.2.0
-          rails_version: 7.0.4
+          ruby_version: 3.2.5
+          rails_version: 7.0.8.4
       - build:
           name: "ruby3-1_rails7-0"
-          ruby_version: 3.1.2
-          rails_version: 7.0.4
-
+          ruby_version: 3.1.6
+          rails_version: 7.0.8.4
       - build:
           name: "ruby3-1_rails6-1"
-          ruby_version: 3.1.2
-          rails_version: 6.1.6
-      - build:
-          name: "ruby3-0_rails6-1"
-          ruby_version: 3.0.3
-          rails_version: 6.1.6
-
-      - build:
-          name: "ruby3-0_rails6-0"
-          ruby_version: 3.0.3
-          rails_version: 6.0.4.7
-      - build:
-          name: "ruby2-7_rails6-0"
-          ruby_version: 2.7.7
-          rails_version: 6.0.4.7
-
-      - build:
-          name: "ruby2-7_rails5-2"
-          ruby_version: 2.7.7
-          rails_version: 5.2.7
-
-      - build:
-          name: "ruby2-7_rails5-1"
-          ruby_version: 2.7.7
-          rails_version: 5.1.7
+          ruby_version: 3.1.6
+          rails_version: 6.1.7.8
 
   nightly:
     triggers:
@@ -103,43 +77,22 @@ workflows:
     jobs:
       - build:
           name: "ruby3-3_rails7-2"
-          ruby_version: 3.3.3
-          rails_version: "7.2.0"
-
+          ruby_version: 3.3.5
+          rails_version: 7.2.1
+      - build:
+          name: "ruby3-2_rails7-1"
+          ruby_version: 3.2.5
+          rails_version: 7.1.4
       - build:
           name: "ruby3-2_rails7-0"
-          ruby_version: 3.2.0
-          rails_version: 7.0.4
+          ruby_version: 3.2.5
+          rails_version: 7.0.8.4
       - build:
           name: "ruby3-1_rails7-0"
-          ruby_version: 3.1.2
-          rails_version: 7.0.4
-
+          ruby_version: 3.1.6
+          rails_version: 7.0.8.4
       - build:
           name: "ruby3-1_rails6-1"
-          ruby_version: 3.1.2
-          rails_version: 6.1.6
-      - build:
-          name: "ruby3-0_rails6-1"
-          ruby_version: 3.0.3
-          rails_version: 6.1.6
-
-      - build:
-          name: "ruby3-0_rails6-0"
-          ruby_version: 3.0.3
-          rails_version: 6.0.4.7
-      - build:
-          name: "ruby2-7_rails6-0"
-          ruby_version: 2.7.7
-          rails_version: 6.0.4.7
-
-      - build:
-          name: "ruby2-7_rails5-2"
-          ruby_version: 2.7.7
-          rails_version: 5.2.7
-
-      - build:
-          name: "ruby2-7_rails5-1"
-          ruby_version: 2.7.7
-          rails_version: 5.1.7
+          ruby_version: 3.1.6
+          rails_version: 6.1.7.8
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.7.5
-nodejs lts-fermium
+ruby   3.1.6
+nodejs lts-gallium


### PR DESCRIPTION
Updating the tool versions and removing Ruby releases prior to 3.1 and Rails releases 6.1. Ensuring that NodeJS is support is limited to LTS Gallium and bundler 2.5.21