### PR TITLE
Remove Bootstrap 3 button loading state method

### DIFF
--- a/app/assets/javascripts/browse_everything/behavior.js
+++ b/app/assets/javascripts/browse_everything/behavior.js
@@ -323,7 +323,6 @@ $(function () {
 
   $(document).on('click', 'button.ev-submit', function (event) {
     event.preventDefault();
-    $(this).button('loading');
     startWait();
     $('form.ev-submit-form').append(Array.from(selected_files.values()));
     var main_form = $(this).closest('form');


### PR DESCRIPTION
Hi! While upgrading our Hyrax-based app to Hyrax 5, we noticed that Browse Everything's submit button was broken for our app. I'll attach a screenshot below of the specific error we're seeing. Running it down, it seems like the root cause is this one line  using Bootstrap 3 plugin behavior that's been removed in Bootstrap 4 (https://getbootstrap.com/docs/3.4/javascript/#buttons-stateful). In our specific case, this line ends up trying to call jQuery UI's button widget (https://api.jqueryui.com/button/), which produces the error in the screenshot. 

This PR removes the outdated button loading state call from Bootstrap 3. The `startWait()` call immediately below should ensure the submit button gets disabled after being clicked regardless. 

Thanks for considering the PR. 

Screenshot of error:
<img width="2552" height="1242" alt="Screenshot 2025-08-22 at 12 36 01 PM" src="https://github.com/user-attachments/assets/344df648-fc91-4db3-86ce-4f25cffbfde6" />
