### PR TITLE
use faraday instead of typhoeus for HTTP retrieval in BrowseEverything::Retriever

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rails', '>= 4.2', '< 8.1'
   spec.add_dependency 'ruby-box'
   spec.add_dependency 'signet', '~> 0.8'
-  spec.add_dependency 'typhoeus'
+  spec.add_dependency 'faraday', "~> 2.0"
 
   # Development dependencies include dependencies necessary for running
   # the dummy test app at ./spec/dummy_test_app

--- a/lib/browse_everything/retriever.rb
+++ b/lib/browse_everything/retriever.rb
@@ -2,25 +2,25 @@
 
 require 'addressable'
 require 'tempfile'
-require 'typhoeus'
+require 'faraday'
 
 module BrowseEverything
   # Class for raising errors when a download is invalid
   class DownloadError < StandardError
-    attr_reader :response
+    attr_accessor :response_body
 
     # Constructor
     # @param msg [String]
-    # @param response [Typhoeus::Response] response from the server
-    def initialize(msg, response)
-      @response = response
+    # @param response [String] response from the server
+    def initialize(msg, response_body)
+      @response_body = response_body
       super(msg)
     end
 
     # Generate the message for the exception
     # @return [String]
     def message
-      "#{super}: #{response.body}"
+      "#{super}: #{response_body}"
     end
   end
 
@@ -36,7 +36,7 @@ module BrowseEverything
       # @param headers [Hash] any custom headers required to transit the request
       def can_retrieve?(uri, headers = {})
         request_headers = headers.merge(Range: 'bytes=0-0')
-        response = Typhoeus.get(uri, headers: request_headers)
+        response = Faraday.get(uri, headers: request_headers)
         response.success?
       end
     end
@@ -133,17 +133,23 @@ module BrowseEverything
       file_size = options.fetch(:file_size)
       headers = options.fetch(:headers)
       url = options.fetch(:url)
-      retrieved = 0
+      error_response = +""
 
-      request = Typhoeus::Request.new(url.to_s, method: :get, headers: headers)
-      request.on_headers do |response|
-        raise DownloadError.new("#{self.class}: Failed to download #{url}: Status Code: #{response.code}", response) unless response.code == 200
+      conn = Faraday.new(url.to_s, headers: headers)
+      response = conn.get do |req|
+        req.options.on_data = proc do |chunk, overall_received_bytes, env|
+          if env.status == 200
+            # will yield to block passed in to outer retrieve_http, amazing.
+            yield(chunk, overall_received_bytes, file_size)
+          else
+            error_response << chunk
+          end
+        end
       end
-      request.on_body do |chunk|
-        retrieved += chunk.bytesize
-        yield(chunk, retrieved, file_size)
+
+      unless response.status == 200
+        raise DownloadError.new("#{self.class}: Failed to download #{url}: Status Code: #{response.status}", error_response)
       end
-      request.run
     end
 
     # Retrieve the file size
@@ -158,7 +164,7 @@ module BrowseEverything
       when 'file'
         File.size(url.path)
       when /https?/
-        response = Typhoeus.head(url.to_s, headers: headers)
+        response = Faraday.head(url.to_s, headers: headers)
         length_value = response.headers['Content-Length'] || file_size
         length_value.to_i
       else

--- a/spec/lib/browse_everything/retriever_spec.rb
+++ b/spec/lib/browse_everything/retriever_spec.rb
@@ -160,12 +160,13 @@ describe BrowseEverything::Retriever do
         stub_request(
           :get, "https://retrieve.cloud.example.com/some/dir/file_error.pdf"
         ).and_return(
-          status: 403
+          status: 403,
+          body: "Did not like this"
         )
       end
 
       it 'raises an exception' do
-        expect { retriever.download(download_options) }.to raise_error(BrowseEverything::DownloadError, /BrowseEverything::Retriever: Failed to download/)
+        expect { retriever.download(download_options) }.to raise_error(BrowseEverything::DownloadError, /BrowseEverything::Retriever: Failed to download.* Status Code: 403.*Did not like this/)
       end
     end
   end
@@ -234,7 +235,7 @@ describe BrowseEverything::Retriever do
       let(:url) { 'https://retrieve.cloud.example.com/some/dir/can_retrieve.pdf' }
       before do
         stub_request(
-          :get, "https://retrieve.cloud.example.com/some/dir/can_retrieve.pdf"
+          :get, %r{^https://retrieve.cloud.example.com/some/dir/can_retrieve.pdf\?}
         ).to_return(
           status: 206,
           body: '%'
@@ -250,7 +251,7 @@ describe BrowseEverything::Retriever do
       let(:url) { 'https://retrieve.cloud.example.com/some/dir/cannot_retrieve.pdf' }
       before do
         stub_request(
-          :get, "https://retrieve.cloud.example.com/some/dir/cannot_retrieve.pdf"
+          :get, %r{^https://retrieve.cloud.example.com/some/dir/cannot_retrieve.pdf\?}
         ).to_return(
           status: 403
         )


### PR DESCRIPTION
Typhoeous is a somewhat unmaintained gem and annoying to have as a dependency for browse-everything.  It was only used in the BrowseEverything::Retriever class, which I dn't even use, but just want to get rid of the dependency. 

It's unlikely anyone would choose to use typhoeous in this day and age, it's not popular.  Switching to faraday would allow us to add API to let you choose your underlying API adapter, but this PR doesn't incldue that, it'll just use the default faraday one (net::http). 

For the most part the use of typhoeous was hidden internally, so this switch does not affect visible API at all, and is not a backwards incompat. One exception is that the BrowseEverything::DownloadError class used to expose a Typhoeous::Response but now it does not, just a String.  I doubt anyone was relying on this API, and think it's prob okay to release this without a major version bump -- we are not in an ideal situation with under maintained b-e anyway. 
