### PR TITLE
Fix Google Drive file listing

### DIFF
--- a/lib/browse_everything/driver/google_drive.rb
+++ b/lib/browse_everything/driver/google_drive.rb
@@ -70,7 +70,7 @@ module BrowseEverything
       # @param path [String] the path (default to the root)
       # @return [Array<BrowseEverything::FileEntry>] file entries for the path
       def list_files(drive, request_params, path: '')
-        drive.list_files(request_params.to_h) do |file_list, error|
+        drive.list_files(**request_params.to_h) do |file_list, error|
           # Raise an exception if there was an error Google API's
           if error.present?
             # In order to properly trigger reauthentication, the token must be cleared


### PR DESCRIPTION
The Google Drive gem's DriveService method `list_files` expects keyword arguments ([method link](https://github.com/googleapis/google-api-ruby-client/blob/22662130e99be4630ea9e985976af79aada9056d/generated/google-apis-drive_v3/lib/google/apis/drive_v3/service.rb#L1488)), and while Ruby 2 was fine converting hashes to keywords, Ruby 3 throws an error on doing so. This PR expands the request params hash to work as keyword arguments.