### PR TITLE
Make dropbox-api gem an 'optional' dependency callers must add themselves to use dropbox driver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,9 @@ group :development, :test do
   gem 'pry-byebug' unless ENV['CI']
 end
 
+# "soft"/"optional" dependency, but needed for our tests of dropbox driver to pass
+gem 'dropbox_api', '>= 0.1.20'
+
 # == Extra dependencies for dummy test app ==
 #
 # Extra dependencies for dummy test app are in .gemspec as a development dependency

--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ download the files.
 
 **This gem does not depend on hydra-head**
 
+## Certain drivers needing maintenance require extra setup
+
+Certain drivers need additional development work if they are to be fully
+supported again, and for now require extra opt-in setup.
+
+### Dropbox
+
+The driver has a dependency on unmaintained dropbox_api gem with it's [own
+dependency on old unmaintained `oauth2` 1.x](https://github.com/Jesus/dropbox_api/issues/96), so requires some opt-in setup and configuration. https://github.com/samvera/browse-everything/pull/448
+
+* Add `dropbox_api, '>= 0.1.20'` to your Gemfile.
+* Add `require 'browse_everything/driver/dropbox'` to a startup file, eg
+  `config/application.rb`.
+
 ## Technical Debt/Legacy warning
 
 This project has been receiving very limited maintenance for at least 2-4 years

--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'aws-sdk-s3'
-  spec.add_dependency 'dropbox_api', '>= 0.1.20'
   spec.add_dependency 'google-apis-drive_v3'
   spec.add_dependency 'googleauth', '>= 0.6.6', '< 2.0'
   spec.add_dependency 'rails', '>= 4.2', '< 8.1'

--- a/lib/browse_everything.rb
+++ b/lib/browse_everything.rb
@@ -12,10 +12,12 @@ module BrowseEverything
   module Driver
     autoload :Base,        'browse_everything/driver/base'
     autoload :FileSystem,  'browse_everything/driver/file_system'
-    autoload :Dropbox,     'browse_everything/driver/dropbox'
     autoload :Box,         'browse_everything/driver/box'
     autoload :GoogleDrive, 'browse_everything/driver/google_drive'
     autoload :S3,          'browse_everything/driver/s3'
+
+    # Intentionally require explicit require, as it has a non-declared dependency
+    # autoload :Dropbox,     'browse_everything/driver/dropbox'
 
     # Access the sorter set for the base driver class
     # @return [Proc]

--- a/lib/browse_everything/driver/dropbox.rb
+++ b/lib/browse_everything/driver/dropbox.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
 
 require 'tmpdir'
-require 'dropbox_api'
 require_relative 'authentication_factory'
+
+# We have an unspecified "optional" dependency, not great but it's what we got
+begin
+  gem 'dropbox_api', '>= 0.1.20'
+rescue Gem::LoadError => e
+  new_raise = Gem::LoadError.new("Loading BrowseEverything::Driver:Dropbox requires the availability of gem dropbox_api '#{e.requirement}', please add it to your Gemfile")
+  new_raise.requirement = e.requirement
+  # raise new_raise, cause: nil # cause is confusing and unneeded here.
+end
 
 module BrowseEverything
   module Driver

--- a/lib/browse_everything/driver/dropbox.rb
+++ b/lib/browse_everything/driver/dropbox.rb
@@ -9,7 +9,7 @@ begin
 rescue Gem::LoadError => e
   new_raise = Gem::LoadError.new("Loading BrowseEverything::Driver:Dropbox requires the availability of gem dropbox_api '#{e.requirement}', please add it to your Gemfile")
   new_raise.requirement = e.requirement
-  # raise new_raise, cause: nil # cause is confusing and unneeded here.
+  raise new_raise, cause: nil # cause is confusing and unneeded here.
 end
 
 module BrowseEverything

--- a/lib/generators/browse_everything/templates/browse_everything_providers.yml.example
+++ b/lib/generators/browse_everything/templates/browse_everything_providers.yml.example
@@ -2,16 +2,10 @@
 # To make browse-everything aware of a provider, uncomment the info for that provider and add your API key information.
 # The file_system provider can be a path to any directory on the server where your application is running.
 #
-# dropbox:
-#   client_id: YOUR_DROPBOX_APP_KEY
-#   client_secret: YOUR_DROPBOX_APP_SECRET
-#   download_directory: tmp/
-# box:
-#   client_id: YOUR_BOX_CLIENT_ID
-#   client_secret: YOUR_BOX_CLIENT_SECRET
 # google_drive:
 #   client_id: YOUR_GOOGLE_API_CLIENT_ID
 #   client_secret: YOUR_GOOGLE_API_CLIENT_SECRET
+#
 # s3:
 #   bucket: YOUR_AWS_S3_BUCKET
 #   response_type: signed_url # set to :public_url for public urls or :s3_uri for an s3://BUCKET/KEY uri
@@ -20,3 +14,19 @@
 #   app_secret: YOUR_AWS_S3_SECRET # explicitly here, or left out to use system-configured
 #   region: YOUR_AWS_S3_REGION     # defaults.
 #   See https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/
+#
+# file_system:
+#   allow_relative_home: true
+#   home: ./browseable_files
+
+# # Note: dropbox requires manual addition of `dropbox_api` gem to Gemfile, and
+# # `require 'browse_everything/driver/dropbox'` in a startup file.
+#
+# dropbox:
+#   client_id: YOUR_DROPBOX_APP_KEY
+#   client_secret: YOUR_DROPBOX_APP_SECRET
+#   download_directory: tmp/
+#
+# box:
+#   client_id: YOUR_BOX_CLIENT_ID
+#   client_secret: YOUR_BOX_CLIENT_SECRET

--- a/spec/helper/browse_everything_controller_helper_spec.rb
+++ b/spec/helper/browse_everything_controller_helper_spec.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+#
+require 'browse_everything/driver/dropbox'
 
 require File.expand_path('../spec_helper', __dir__)
 

--- a/spec/lib/browse_everything/browser_spec.rb
+++ b/spec/lib/browse_everything/browser_spec.rb
@@ -4,7 +4,7 @@ include BrowserConfigHelper
 
 describe BrowseEverything::Browser do
   let(:file_config) do
-    "file_system:\n  home: '/file/config/home'\ndropbox:\n  client_id: 'DropboxId'\n  client_secret: 'DropboxClientSecret'\n  download_directory: 'tmp/'"
+    "file_system:\n  home: '/file/config/home'\ngoogle_drive:\n  client_id: 'GoogleDriveId'\n  client_secret: 'GoogleDriveClientSecret'\n  download_directory: 'tmp/'"
   end
 
   let(:global_config) do
@@ -12,7 +12,7 @@ describe BrowseEverything::Browser do
       file_system: {
         home: '/global/config/home'
       },
-      dropbox: {
+      google_drive: {
         client_id: 'DropboxId',
         client_secret: 'DropboxClientSecret',
         download_directory: 'tmp/'
@@ -25,9 +25,9 @@ describe BrowseEverything::Browser do
       file_system: {
         home: '/local/config/home'
       },
-      dropbox: {
-        client_id: 'DropboxId',
-        client_secret: 'DropboxClientSecret',
+      google_drive: {
+        client_id: 'GoogleDriveId',
+        client_secret: 'GoogleDriveClientSecret',
         download_directory: 'tmp/'
       },
       url_options: url_options
@@ -43,9 +43,9 @@ describe BrowseEverything::Browser do
     end
 
     it 'has 2 providers' do
-      expect(browser.providers.keys).to eq(%w[file_system dropbox])
+      expect(browser.providers.keys).to eq(%w[file_system google_drive])
       expect(browser.providers[:file_system]).to be_a BrowseEverything::Driver::FileSystem
-      expect(browser.providers[:dropbox]).to be_a BrowseEverything::Driver::Dropbox
+      expect(browser.providers[:google_drive]).to be_a BrowseEverything::Driver::GoogleDrive
     end
 
     it 'uses the file configuration' do
@@ -60,9 +60,9 @@ describe BrowseEverything::Browser do
     before { BrowseEverything.configure(global_config) }
 
     it 'has 2 providers' do
-      expect(browser.providers.keys).to eq(%w[file_system dropbox])
+      expect(browser.providers.keys).to eq(%w[file_system google_drive])
       expect(browser.providers[:file_system]).to be_a BrowseEverything::Driver::FileSystem
-      expect(browser.providers[:dropbox]).to be_a BrowseEverything::Driver::Dropbox
+      expect(browser.providers[:google_drive]).to be_a BrowseEverything::Driver::GoogleDrive
     end
 
     it 'uses the global configuration' do
@@ -75,9 +75,9 @@ describe BrowseEverything::Browser do
     let(:browser) { described_class.new(local_config) }
 
     it 'has 2 providers' do
-      expect(browser.providers.keys).to eq(%w[file_system dropbox])
+      expect(browser.providers.keys).to eq(%w[file_system google_drive])
       expect(browser.providers[:file_system]).to be_a BrowseEverything::Driver::FileSystem
-      expect(browser.providers[:dropbox]).to be_a BrowseEverything::Driver::Dropbox
+      expect(browser.providers[:google_drive]).to be_a BrowseEverything::Driver::GoogleDrive
     end
 
     it 'uses the local configuration' do

--- a/spec/lib/browse_everything/driver/dropbox_spec.rb
+++ b/spec/lib/browse_everything/driver/dropbox_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'browse_everything/driver/dropbox'
+
 include BrowserConfigHelper
 
 describe BrowseEverything::Driver::Dropbox do


### PR DESCRIPTION
## Motivation

dropbox-api is fairly unmaintained, and has it's own old dependencies which are causing problems for some browse-everything users that don't even use the dropbox driver.  Including possible security concerns with dependency on unmaintained `oauth2` 1.x version.  Ref #422 

* some people were still using dropbox driver and it was still working for them (Before we realized this, there was a consensus to drop dropbox driver)
* We don't have the current capacity to fix this in a "good" way (fork dropbox-api or rewrite dropbox driver not to use it)

So after some discussion with @cjcolvar and @JulieWinchester , the best thing to do seems to be to drop `dropbox_api` gem from the gemspec, but leave the dropbox driver here -- implementers wanting to use it will have to add `dropbox_api` to their own local Gemspec -- and those who don't want to use the dropbox driver won't have to pay the outdated dependency conflict price. 

Not ideal, but seems like the best solution for now until it can be either improved or dropped. 

## Implementation

The dropbox driver is already loaded with an old-style [traditional ruby stdlib `autoload`](https://github.com/samvera/browse-everything/blob/main/lib/browse_everything.rb#L15B). So it's automatically loaded/interpreted when `BrowseEveryting::Dropbox::Driver` is referenced, but not before. 

[I added a pattern I have used before](https://github.com/samvera/browse-everything/blob/6307ac3af393c395c70b3723dd9cdee8e64d8d3a/lib/browse_everything/driver/dropbox.rb#L7-L13) such that when/if the driver is loaded, it will check for suitable availability of `dropbox_api` dependency, and give you a nice error message if not. Trying to make as good DX as we can for this confusing situation:

dropbox_api is _not_ in gemspec -- but we do need to it to `Gemfile`, so it will be available to run tests, because we need it to pass the tests!  I did remove dropbox as "example" in tests it didn't need to be the example, to decouple further -- but we still gotta test the dropbox driver itself. 

So one downside is we're testing in an environment different from app -- we can't guarantee we don't accidentally have a dropbox dependency elsewhere. 

## Or, would it be simpler?

Should we drop the `autoload`, and say in the new major version of b-e, if you want to use the dropbox driver, you have to explicitly drop `require "browse_everything/driver/dropbox"` into your app boot?  I think that would make things somewhat less confusing and less error prone, and think I would like to do that -- didn't realize until I had analyzed and written this whole thing up (thanks rubber duck). 

Feedback welcome on this approach. Still needs something added to doc to explain it, which is a bit tricky in the old unmaintained docs... or should the note be in the generated config file rather than the README?  (I honestly don't know if the generator currently even works!)

