### PR TITLE
Make unmaintained ruby-box an optional dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ end
 
 # "soft"/"optional" dependency, but needed for our tests of dropbox driver to pass
 gem 'dropbox_api', '>= 0.1.20'
+gem 'ruby-box'
 
 # == Extra dependencies for dummy test app ==
 #

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ dependency on old unmaintained `oauth2` 1.x](https://github.com/Jesus/dropbox_ap
 * Add `require 'browse_everything/driver/dropbox'` to a startup file, eg
   `config/application.rb`.
 
+### Box.com
+
+The driver uses unmaintained [ruby-box](https://github.com/attachmentsme/ruby-box)
+gem, which should probably be replaced with [boxr](https://github.com/cburnette/boxr).
+See unfinished work at https://github.com/samvera/browse-everything/pull/185
+
+* Add `ruby-box` to your Gemfile.
+* Add `require 'browse_everything/driver/box'` to a startup file, eg
+  `config/application.rb`.
+
+
 ## Technical Debt/Legacy warning
 
 This project has been receiving very limited maintenance for at least 2-4 years

--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-apis-drive_v3'
   spec.add_dependency 'googleauth', '>= 0.6.6', '< 2.0'
   spec.add_dependency 'rails', '>= 4.2', '< 8.1'
-  spec.add_dependency 'ruby-box'
   spec.add_dependency 'signet', '~> 0.8'
   spec.add_dependency 'faraday', "~> 2.0"
 

--- a/lib/browse_everything.rb
+++ b/lib/browse_everything.rb
@@ -12,12 +12,12 @@ module BrowseEverything
   module Driver
     autoload :Base,        'browse_everything/driver/base'
     autoload :FileSystem,  'browse_everything/driver/file_system'
-    autoload :Box,         'browse_everything/driver/box'
     autoload :GoogleDrive, 'browse_everything/driver/google_drive'
     autoload :S3,          'browse_everything/driver/s3'
 
     # Intentionally require explicit require, as it has a non-declared dependency
     # autoload :Dropbox,     'browse_everything/driver/dropbox'
+    # autoload :Box,         'browse_everything/driver/box'
 
     # Access the sorter set for the base driver class
     # @return [Proc]

--- a/lib/browse_everything/driver/box.rb
+++ b/lib/browse_everything/driver/box.rb
@@ -1,7 +1,14 @@
 # frozen_string_literal: true
 
-require 'ruby-box'
 require_relative 'authentication_factory'
+
+begin
+  gem 'ruby-box'
+rescue Gem::LoadError => e
+  new_raise = Gem::LoadError.new("Loading BrowseEverything::Driver:Box requires the availability of gem ruby-box #{e.requirement}, please add it to your Gemfile")
+  new_raise.requirement = e.requirement
+  raise new_raise, cause: nil # cause is confusing and unneeded here.
+end
 
 module BrowseEverything
   module Driver

--- a/lib/generators/browse_everything/templates/browse_everything_providers.yml.example
+++ b/lib/generators/browse_everything/templates/browse_everything_providers.yml.example
@@ -18,7 +18,7 @@
 # file_system:
 #   allow_relative_home: true
 #   home: ./browseable_files
-
+#
 # # Note: dropbox requires manual addition of `dropbox_api` gem to Gemfile, and
 # # `require 'browse_everything/driver/dropbox'` in a startup file.
 #
@@ -26,6 +26,9 @@
 #   client_id: YOUR_DROPBOX_APP_KEY
 #   client_secret: YOUR_DROPBOX_APP_SECRET
 #   download_directory: tmp/
+#
+# # Note: box requires addition of `ruby-box` to Gemfile, and
+# # `require 'browse_everything/driver/box'` in a startup file.
 #
 # box:
 #   client_id: YOUR_BOX_CLIENT_ID

--- a/spec/lib/browse_everything/driver/box_spec.rb
+++ b/spec/lib/browse_everything/driver/box_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'browse_everything/driver/box'
+
 include BrowserConfigHelper
 
 describe BrowseEverything::Driver::Box do


### PR DESCRIPTION
Parallel to #448.  If we are doing a major release, let's do this now, move aside unmaintained dependencies from dependency tree. For box.com, could be a step to removing, depending on if it's still getting used.
