### PR TITLE
Remove signet dependency

### DIFF
--- a/browse-everything.gemspec
+++ b/browse-everything.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'googleauth', '>= 0.6.6', '< 2.0'
   spec.add_dependency 'rails', '>= 4.2', '< 8.1'
   spec.add_dependency 'ruby-box'
-  spec.add_dependency 'signet', '~> 0.8'
   spec.add_dependency 'faraday', "~> 2.0"
 
   # Development dependencies include dependencies necessary for running


### PR DESCRIPTION
Signet is an [indirect dependency via googleauth](lib/browse_everything/driver/box.rb), which we have as an indirect dependency via `google-apis-drive_v3` => `google-apis-core` => `googleauth`.

The _only_ place in our code we use it is in the spec file where we mock it? https://github.com/samvera/browse-everything/blob/bb296632518f3d1b9700e2440144277d42a34554/spec/controllers/browse_everything_controller_spec.rb#L59

I guess we're mocking certain error behavior under google drive?  This isn't necessarily a great thing to put in a generic spec (rather than google drive one), but I don't believe we need it as a direct dependency -- we indeed only have it as an indirect dependency, and don't need to list it separately raising confusion and possible conflict with future versions of our dependency tree (say accidentally holding back to an earlier version than we needed/wanted).
