### PR TITLE
Bump version to 2.0.0.alpha.2

### DIFF
--- a/lib/browse_everything/version.rb
+++ b/lib/browse_everything/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BrowseEverything
-  VERSION = '2.0.0.alpha.1'
+  VERSION = '2.0.0.alpha.2'
 end


### PR DESCRIPTION
The ONLY difference this release will have from 2.0.0.alpha.1 is allowing Rails 8.1, but let's get that out there before possibly larger changes are merged. 

https://github.com/samvera/browse-everything/compare/v2.0.0.alpha.1..main


